### PR TITLE
docs: document Tag Team v0.5.0 (changelog, website changelog, features)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [0.5.0] — 2026-07-09
+
+### Added — Tag Team (sequential model relay)
+- **Tag Team — a Pi Desktop exclusive.** The opposite of Pi Routing/MOA: instead of running models in parallel, models work **sequentially**. The starter model builds out the work, then **tags** the next model, which takes over in a new tab and improves it — automatically, no clicks. Each handoff tab carries the previous model's output plus a per-stage handoff prompt (not the whole history), so the relay is context-efficient.
+- **Multi-stage relay.** Teams have 2+ ordered stages (e.g. build → review → finalize). Each handoff tab is itself armed for the following stage, so the relay chains all the way through to the finalizer — not just a single A→B hop.
+- **Full team management** — a new **Tag Team** sidebar panel to create/edit/delete teams, set each stage's model + role, write handoff prompts, and **Test** the relay (runs sequentially and previews every stage's output) before using it live. Config persists to `tag-teams.json` in `userData`.
+- **Chat integration** — a toolbar button cycles through teams and shows the active one; **TAG badges** mark handoff-created tabs; a handoff indicator shows "Model A → Model B · new tab."
+
+### Fixed — Pi Routing (Mixture of Agents)
+- **MOA now loads** — fixed `ERR_PACKAGE_PATH_NOT_EXPORTED` that stopped the engine from importing pi-ai's `compat` layer. It now resolves the nested `@earendil-works/pi-ai/dist/compat.js` by absolute file path (cached), bypassing the package `exports` map; works in dev and inside the packaged asar. (`getCompat`/`resolveNestedCompat` in `moa/engine.ts`, reused by the Tag Team orchestrator.)
+- **Test unsaved drafts** — the MOA and Tag Team Test buttons run against the in-editor draft (team object passed directly) instead of throwing "Team not found."
+- **Editor polish** — provider badges + accent borders on selected models; a custom, consistently-spaced dropdown chevron; the routing toggle shows the team name instead of the word "Routing."
+
+### Fixed — Tag Team hardening (pre-release review)
+- Live relay now chains through **all** stages (was stopping after the first handoff). The next model always receives the previous output embedded directly in its prompt — no reliance on a session-internal seed that could silently no-op. Removed a duplicate handoff event that fired with null tab ids, and fixed a `setActiveTab` type error that was breaking `npm run typecheck`.
+
+---
+
 ## [0.4.7] — 2026-07-08
 
 ### Fixed

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Pi Desktop — Features
 
-_Website-ready feature copy. Version 0.4.0 · macOS (Apple Silicon + Intel)._
+_Website-ready feature copy. Version 0.5.0 · macOS (Apple Silicon + Intel)._
 
 **Pi Desktop is a native macOS app for the [Pi coding agent](https://pi.dev) — a polished, multi-tab GUI that replaces the terminal. No CLI, no Node.js setup. Just open it and start.**
 
@@ -9,6 +9,7 @@ _Website-ready feature copy. Version 0.4.0 · macOS (Apple Silicon + Intel)._
 ## Highlights
 
 - **🔀 Pi Routing (Mixture of Agents).** A Pi Desktop exclusive. Create a team of models that collaborate on every prompt — they respond in parallel, synthesize a briefing, and the main model builds its answer enriched by the team's analysis. Basic and Advanced modes.
+- **🏷 Tag Team (Sequential Model Relay).** A Pi Desktop exclusive. Chain models to work in sequence — the starter builds, then tags the next model to review, improve, and finalize in a fresh tab, automatically.
 - **Launches into chat.** Open the app and start typing — no folder, no setup.
 - **Chat or Code, your choice.** Quick conversations or full project sessions, one toggle away.
 - **⚡ Turn a chat into code.** Promote any conversation into a real project session — with the whole chat carried forward as context.
@@ -64,6 +65,27 @@ The Pi Routing button in the chat toolbar (next to Tools and Web) turns routing 
 
 **Live progress**
 A subtle indicator in the chat area shows "Pi Routing: consulting 3 models…" during fan-out, so you always know the team is working.
+
+---
+
+## Tag Team — Sequential Model Relay
+
+**A Pi Desktop exclusive.** The counterpart to Pi Routing: where MOA runs models in **parallel**, Tag Team runs them in **sequence**.
+
+**How the relay works**
+The starter model builds out your request, then **tags** the next model in the team. That model takes over in a brand-new tab, receives the previous model's output plus a handoff prompt, and improves the work — no clicks needed. It keeps going stage by stage until the final model, so a team like **build → review → finalize** runs end-to-end on its own.
+
+**Context-efficient by design**
+Each stage gets a fresh tab carrying only what it needs — the previous output and the handoff prompt — not the entire conversation history. Long relays stay lean.
+
+**Custom handoff prompts**
+Every stage carries an instruction for the next model: "Review the code above and fix bugs," "Optimize for performance," "Add tests." Write them once; every relay reuses them.
+
+**Team management**
+The **Tag Team** sidebar panel lets you create teams with two or more ordered stages, set each stage's model and role, reorder stages, write handoff prompts, and **Test** the full relay — previewing every stage's output — before using it live. Create as many teams as you like and cycle through them from the chat toolbar.
+
+**At-a-glance in chat**
+A toolbar button cycles through your teams and shows the active one. **TAG badges** in the tab bar mark handoff-created tabs, and a handoff indicator shows the relay passing from one model to the next.
 
 ---
 

--- a/docs/WEBSITE_CHANGELOG.md
+++ b/docs/WEBSITE_CHANGELOG.md
@@ -14,6 +14,7 @@
 - **Saves context window.** Each model gets its own fresh tab with only what it needs — Model B carries Model A's output and the handoff prompt, not the entire conversation history.
 - **Full team management.** The new **Tag Team** sidebar panel lets you build teams with 2+ stages, set each stage's model and role, reorder stages, write handoff prompts, and test the relay before using it. Create as many teams as you want and cycle through them from the chat toolbar.
 - **TAG badges in the tab bar** show at a glance which tabs are relay handoffs.
+- **Relays all the way through.** A team isn't capped at two models — each stage hands off to the next until the finalizer, so a **build → review → finalize** team runs end-to-end on its own.
 
 ### Pi Routing (Mixture of Agents)
 - The toolbar toggle now shows the **team name** instead of the word "Routing," so you always see what's active at a glance.


### PR DESCRIPTION
Follow-up to #2 — updates the three release-facing docs that the Tag Team v0.5.0 work missed.

- **CHANGELOG.md** — adds the missing `[0.5.0]` entry (the app changelog had jumped from 0.4.7 straight past the feature): Tag Team sequential relay, the MOA `ERR_PACKAGE_PATH_NOT_EXPORTED` fix, and the pre-release hardening from #2.
- **docs/WEBSITE_CHANGELOG.md** — notes that the relay chains through every stage to the finalizer (reflecting the multi-stage fix), not just a single A→B hop.
- **docs/FEATURES.md** — bumps the version line to 0.5.0, adds a Tag Team entry to Highlights, and adds a full **Tag Team — Sequential Model Relay** section alongside Pi Routing.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)