### PR TITLE
chore: clear all 36 ESLint warnings (no behavior change)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ export default tseslint.config(
       // Unused vars are a warning (caught here rather than blocking the build).
       "@typescript-eslint/no-unused-vars": [
         "warn",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrors: "none" },
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrors: "none", ignoreRestSiblings: true },
       ],
       // Empty catch blocks are an intentional pattern (best-effort cleanup).
       "no-empty": ["warn", { allowEmptyCatch: true }],

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,7 +3,7 @@ import { SessionPool } from "./pi/SessionPool";
 import { getGitInfoCached } from "./git";
 import { checkPiInstalled } from "./installer";
 import { invalidateSharedDeps } from "./pi/SharedDepsCache";
-import { getCachedMessages, setCachedMessages, invalidateCache } from "./pi/MessageCache";
+import { getCachedMessages, setCachedMessages } from "./pi/MessageCache";
 import {
   storeGitHubToken,
   getGitHubToken,
@@ -26,7 +26,7 @@ import { getExtensionDetail, setExtensionConfig } from "./extensionDetail";
 import { getAddonContributions } from "./addonContributions";
 import { getSdkVersion } from "./pi/sdkVersion";
 import { loadFavorites, saveFavorites, type Favorite } from "./favorites";
-import { loadMoaConfig, saveMoaConfig, findTeam } from "./moa/config";
+import { loadMoaConfig, saveMoaConfig } from "./moa/config";
 import { loadTagTeamConfig, saveTagTeamConfig } from "./tagteam/config";
 import { shell } from "electron";
 import { homedir } from "node:os";

--- a/src/main/pi/PiSessionManager.ts
+++ b/src/main/pi/PiSessionManager.ts
@@ -23,7 +23,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { getSharedDeps, invalidateSharedDeps } from "./SharedDepsCache";
 import { listCustomProviderCredentials } from "../models";
-import { getCachedMessages, setCachedMessages, invalidateCache } from "./MessageCache";
+import { invalidateCache } from "./MessageCache";
 import {
   createExtensionUiBridge,
   type ExtUiDialogRequest,
@@ -809,13 +809,13 @@ export class PiSessionManager {
     });
   }
 
-  async steer(message: string, images?: any[]) {
+  async steer(message: string, _images?: any[]) {
     if (!this.session) throw new Error("Session not initialized");
     await this.session.steer(message);
     return { success: true };
   }
 
-  async followUp(message: string, images?: any[]) {
+  async followUp(message: string, _images?: any[]) {
     if (!this.session) throw new Error("Session not initialized");
     await this.session.followUp(message);
     return { success: true };
@@ -1097,7 +1097,7 @@ export class PiSessionManager {
 
   async cycleModel() {
     if (!this.session) throw new Error("Session not initialized");
-    const res = await this.session.cycleModel();
+    await this.session.cycleModel();
     this.emitState();
     return this.getState();
   }
@@ -1659,7 +1659,6 @@ export class PiSessionManager {
   // --- Session rename & export -------------------------------------------
 
   async renameSession(name: string) {
-    const pi = await import("@earendil-works/pi-coding-agent");
     // renameSession isn't on AgentSession directly; we use set_session_name via RPC-style
     // For SDK, we write to the session manager
     if (this.session?.sessionFile && this.sessionManager) {

--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -1,4 +1,4 @@
-import { globalShortcut, BrowserWindow, app } from "electron";
+import { globalShortcut, BrowserWindow } from "electron";
 
 /** Toggle window visibility via a global hotkey. */
 export function registerShortcuts(getMainWindow: () => BrowserWindow | null): void {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -129,7 +129,6 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void
       // Read the stream chunk-by-chunk so we can report progress to the
       // renderer, which shows a percentage on the Download button.
       // (Node 20+ web streams: pump via getReader on the ReadableStream.)
-      // eslint-disable-next-line no-constant-condition
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -236,7 +236,7 @@ export default function App() {
       offReset();
       offMenu();
     };
-  }, [handleTabAgentEvent, setTabPiState, setTabQueue, loadTabMessages, resetTabMessages, addDiagnostic, handleExtUi, handleAuthEvent, loadAddons, addTab, setActiveView, setSidebarOpen]);
+  }, [handleTabAgentEvent, setTabPiState, setTabQueue, loadTabMessages, resetTabMessages, addDiagnostic, handleExtUi, handleAuthEvent, loadAddons, addTab, setActiveView, setSidebarOpen, setActiveTab, setSessionsPanelOpen]);
 
   // Sync active tab to backend when renderer switches tabs.
   useEffect(() => {

--- a/src/renderer/src/components/GitHubBadge.tsx
+++ b/src/renderer/src/components/GitHubBadge.tsx
@@ -303,7 +303,7 @@ export function GitHubBadge() {
           {/* CREATE REPO */}
           {menuView === "create" && (
             <div className="p-3">
-              <BackButton onClick={() => setMenuView("main")} label="Create New Repo" />
+              <BackButton onClick={() => setMenuView("main")} />
               <input
                 type="text"
                 value={repoName}
@@ -331,7 +331,7 @@ export function GitHubBadge() {
           {menuView === "attach" && (
             <div>
               <div className="px-3 pb-2">
-                <BackButton onClick={() => setMenuView("main")} label="Attach Existing Repo" />
+                <BackButton onClick={() => setMenuView("main")} />
                 <input
                   type="text"
                   value={repoSearch}
@@ -370,7 +370,7 @@ export function GitHubBadge() {
   );
 }
 
-function BackButton({ onClick, label }: { onClick: () => void; label: string }) {
+function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       onClick={onClick}

--- a/src/renderer/src/components/packages/PackagesView.tsx
+++ b/src/renderer/src/components/packages/PackagesView.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from "react";
-import { useAppStore } from "../../store/useAppStore";
 import type { PackageInfo, InstalledPackage } from "../../../../shared/ipc";
 
 type SortMode = "downloads" | "recent" | "az";


### PR DESCRIPTION
Cleans up every ESLint warning surfaced by the v0.5.0 CI run so `npm run lint` is green. **No behavior or version change** — purely internal hygiene.

### Changes
- **Unused imports removed** — `invalidateCache` (ipc.ts), `findTeam` (ipc.ts), `getCachedMessages`/`setCachedMessages` (PiSessionManager), `app` (shortcuts.ts), `useAppStore` (PackagesView).
- **Unused args/vars** — `_images` prefix on `steer`/`followUp` (param kept for API parity); dropped the unused `res` (cycleModel) and `pi` (renameSession) locals.
- **Stale directive** — removed an unused `eslint-disable no-constant-condition` in updater.ts.
- **Dead prop** — `GitHubBadge`'s `BackButton` took a `label` prop it never rendered (the button hardcodes "Back"); removed the prop + the two call-site `label="…"` attributes. *(See note below.)*
- **exhaustive-deps** — added the two missing deps (`setActiveTab`, `setSessionsPanelOpen`) to App.tsx's event-wiring effect. Both are stable Zustand setters, so no re-subscribe churn.
- **eslint config** — enabled `ignoreRestSiblings` so react-markdown's `{ node, ...props }` renderers stop flagging `node` (23 of the 36 warnings); `node` is intentionally destructured to keep it off the DOM element.

### Verification
- ✅ `npm run lint` — 0 problems (was 36 warnings)
- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run build` — passes

> **Note / possible latent bug:** `BackButton` was being passed `label="Create New Repo"` and `label="Attach Existing Repo"`, but it always rendered "Back". I removed the ignored prop (behavior unchanged). If those buttons were meant to show those labels, that's a separate one-line fix — happy to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)