### PR TITLE
Icon-only Routing/Tag Team toggles + enable them in code mode

### DIFF
--- a/src/renderer/src/components/chat/PromptInput.tsx
+++ b/src/renderer/src/components/chat/PromptInput.tsx
@@ -386,8 +386,9 @@ export function PromptInput() {
                   Web
                 </button>
               )}
-              {mode === "chat" && <RoutingToggle />}
-              {mode === "chat" && <TagTeamToggle />}
+              {/* Routing (MOA) and Tag Team work in both chat and code sessions. */}
+              <RoutingToggle />
+              <TagTeamToggle />
               {mode === "chat" && !isStreaming && (
                 <button
                   onClick={handleConvertToCode}

--- a/src/renderer/src/components/chat/RoutingToggle.tsx
+++ b/src/renderer/src/components/chat/RoutingToggle.tsx
@@ -82,7 +82,10 @@ export function RoutingToggle() {
         }}
         disabled={!hasTeams}
         title={title}
-        className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors ${
+        aria-label="Pi Routing"
+        className={`flex items-center gap-1.5 rounded-lg border py-1.5 text-xs font-medium transition-colors ${
+          routingEnabled && activeTeam ? "px-2.5" : "px-2"
+        } ${
           routingEnabled
             ? "border-accent/40 bg-accent/15 text-accent"
             : hasTeams
@@ -91,11 +94,8 @@ export function RoutingToggle() {
         }`}
       >
         <PiRoutingIcon size={12} />
-        {routingEnabled && activeTeam
-          ? activeTeam.name
-          : hasTeams
-            ? teams[0]?.name ?? "Routing"
-            : "Routing"}
+        {/* Show only the icon until a team is active; then show its name. */}
+        {routingEnabled && activeTeam && <span>{activeTeam.name}</span>}
       </button>
 
       {dropdownOpen && hasTeams && (

--- a/src/renderer/src/components/chat/TagTeamToggle.tsx
+++ b/src/renderer/src/components/chat/TagTeamToggle.tsx
@@ -64,7 +64,10 @@ export function TagTeamToggle() {
       onClick={cycle}
       disabled={!hasTeams}
       title={title}
-      className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors ${
+      aria-label="Tag Team"
+      className={`flex items-center gap-1.5 rounded-lg border py-1.5 text-xs font-medium transition-colors ${
+        tagTeamEnabled && activeTeam ? "px-2.5" : "px-2"
+      } ${
         tagTeamEnabled
           ? "border-accent/40 bg-accent/15 text-accent"
           : hasTeams
@@ -73,7 +76,8 @@ export function TagTeamToggle() {
       }`}
     >
       <TagTeamIcon size={12} />
-      {tagTeamEnabled && activeTeam ? activeTeam.name : hasTeams ? teams[0]?.name ?? "Tag Team" : "Tag Team"}
+      {/* Show only the icon until a team is active; then show its name. */}
+      {tagTeamEnabled && activeTeam && <span>{activeTeam.name}</span>}
     </button>
   );
 }


### PR DESCRIPTION
## What

Three chat-toolbar changes:

1. **Pi Routing toggle** — shows only its icon until a team is active; once active, shows the configured team's name. Previously it always showed the first team's name even when off.
2. **Tag Team toggle** — same behavior: icon-only until active, then the active team's name.
3. **Routing + Tag Team now appear in code mode** — after you select a folder (code session), both toggles render, not just in chat.

## Why

- The always-visible team name made the toggles look "on" when they weren't, and cluttered the toolbar. Users asked to see just the icon until they activate a team, then the name they configured.
- Selecting a folder (switching to a code session) hid Routing and Tag Team entirely. Their backend (`setRoutingEnabled` / `setTagTeamEnabled`) is mode-agnostic and the routing/relay pre-processing runs on prompt regardless of mode, so there was no reason to hide them — just a UI gate.

## Reviewer notes

- **Web and Tools were intentionally left chat-only.** Code sessions already have all native tools enabled, so a Tools toggle there is redundant. The chat Web/Tools path calls `session.setActiveToolsByName(...)`, which **replaces the entire active tool set** — enabling it in code mode would wipe the code session's tools (read/edit/bash/…). Making Web work in code needs an *additive* backend change (append web tools to the code set + register the native web tool for code sessions); that's a tracked follow-up, not in this PR.
- No version bump or changelog entry here — this is up for review/preview before release. Verified locally: `typecheck`, `lint` (0 errors), `build` all pass.

## Files

- `src/renderer/src/components/chat/RoutingToggle.tsx`
- `src/renderer/src/components/chat/TagTeamToggle.tsx`
- `src/renderer/src/components/chat/PromptInput.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)