### PR TITLE
fix: Pi Routing asar resolution + streaming freeze (v0.5.6)

### DIFF
--- a/docs/WEBSITE_CHANGELOG.md
+++ b/docs/WEBSITE_CHANGELOG.md
@@ -1,8 +1,18 @@
 # Pi Desktop — Website Changelog
 
 > **Source of truth for pi-desktop.dev.**
-> Current version: **v0.5.5** · Last updated: **July 11, 2026**
+> Current version: **v0.5.6** · Last updated: **July 13, 2026**
 > Copy directly into the website's changelog section.
+
+---
+
+## v0.5.6 — July 13, 2026
+
+### Pi Routing — now works in the installed app
+- **Fixed.** Pi Routing (Mixture of Agents) was failing in the packaged app with "Could not locate pi-ai/compat." The root cause: electron-builder flattens npm dependencies inside the asar bundle, so the compat module moved from a nested path to a top-level path. The engine now checks both layouts and uses `createRequire` to load from inside the asar — MOA and Tag Team both work in the installed DMG now.
+
+### Streaming freeze fix
+- **The UI no longer freezes after a model finishes.** A coding session on AgentMail revealed that when the model completed normally, the "Thinking..." indicator could stay forever and the input stayed disabled — because `isStreaming: false` was set in only one event handler with no fallback. Now streaming resets on three independent signals: the message-end event with a terminal stop reason, backend state pushes, and a 30-second watchdog that force-resets any stuck tab. A single missed event can never freeze the app again.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.6",
+        "@esbuild/darwin-arm64": "^0.28.1",
         "@types/react-syntax-highlighter": "^15.5.13",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
@@ -2613,15 +2614,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -6359,6 +6358,23 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
@@ -7434,6 +7450,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -11722,24 +11739,6 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
       ],
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Pi Desktop - a full-featured macOS desktop app for the Pi coding agent",
   "main": "out/main/index.js",
   "author": "Pi Desktop",
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.6",
+    "@esbuild/darwin-arm64": "^0.28.1",
     "@types/react-syntax-highlighter": "^15.5.13",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",

--- a/src/main/moa/engine.ts
+++ b/src/main/moa/engine.ts
@@ -444,31 +444,68 @@ export async function getCompat(): Promise<any> {
       // under the app; falling back to cwd covers any CJS edge case.
       const here = (import.meta as any).url ?? pathToFileURL(process.cwd() + "/").href;
       const compatFile = resolveNestedCompat(here);
-      return await import(pathToFileURL(compatFile).href);
+
+      // Dynamic import() does NOT work for files packed inside an asar archive
+      // because Node's ESM loader doesn't understand the asar format. Electron
+      // patches require() (and by extension createRequire) to handle asar
+      // transparently. So we try require first, then fall back to import for
+      // dev mode where the file is a regular .js on disk.
+      try {
+        const { createRequire } = await import("node:module");
+        const req = createRequire(here);
+        return req(compatFile);
+      } catch {
+        // Dev mode or unpacked file — ESM import works here.
+        return await import(pathToFileURL(compatFile).href);
+      }
     })();
   }
   return compatModulePromise;
 }
 
 /**
- * Walk up from `fromUrl` looking for `node_modules/@earendil-works/pi-coding-agent`,
- * then return the absolute path to its nested pi-ai compat entry. Throws if the
- * package can't be located (e.g. dependency not installed).
+ * Walk up from `fromUrl` looking for the pi-ai compat module.
+ *
+ * Checks two layouts on every directory level:
+ * 1. FLATTENED: `node_modules/@earendil-works/pi-ai/dist/compat.js`
+ *    This is what electron-builder produces in the asar — it hoists nested
+ *    deps to the top level.
+ * 2. NESTED: `node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/compat.js`
+ *    This is what npm produces in dev — pi-ai is a nested dep of pi-coding-agent.
+ *
+ * Without checking both, MOA works in dev but fails in the packaged app
+ * (or vice versa).
  */
 function resolveNestedCompat(fromUrl: string): string {
   let dir = dirname(fileURLToPath(fromUrl));
-  const root = dirname(process.cwd());
-  while (dir && dir !== root && dir !== dirname(dir)) {
-    const agentDir = join(dir, "node_modules", "@earendil-works", "pi-coding-agent");
-    const compatFile = join(
-      agentDir,
+  for (let i = 0; i < 20; i++) {
+    if (!dir || dir === dirname(dir)) break;
+
+    // 1. Flattened layout (asar / production).
+    const flatCompat = join(
+      dir,
       "node_modules",
       "@earendil-works",
       "pi-ai",
       "dist",
       "compat.js",
     );
-    if (existsSync(compatFile)) return compatFile;
+    if (existsSync(flatCompat)) return flatCompat;
+
+    // 2. Nested layout (npm dev install).
+    const nestedCompat = join(
+      dir,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "node_modules",
+      "@earendil-works",
+      "pi-ai",
+      "dist",
+      "compat.js",
+    );
+    if (existsSync(nestedCompat)) return nestedCompat;
+
     dir = dirname(dir);
   }
   throw new Error(

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -249,6 +249,31 @@ export default function App() {
     };
   }, [handleTabAgentEvent, setTabPiState, setTabQueue, loadTabMessages, resetTabMessages, addDiagnostic, handleExtUi, handleAuthEvent, loadAddons, addTab, setActiveView, setSidebarOpen, setActiveTab, setSessionsPanelOpen]);
 
+  // Streaming watchdog: polls every 30s. If any tab is stuck in isStreaming
+  // but the backend session reports not streaming, force-reset it. This is the
+  // last line of defense against UI freezes when agent_end is missed/delayed.
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const store = useAppStore.getState();
+      const stuckTabs = store.tabs.filter(
+        (t) => store.tabStates[t.id]?.piState?.isStreaming,
+      );
+      for (const tab of stuckTabs) {
+        try {
+          const state = await window.pi.api.getState({ tabId: tab.id });
+          // If the backend says not streaming, the UI is stale — force reset.
+          if (state && !state.isStreaming) {
+            useAppStore.getState().setTabPiState(tab.id, { isStreaming: false });
+          }
+        } catch {
+          // Tab might be gone or session disposed — force-reset to unstick UI.
+          useAppStore.getState().setTabPiState(tab.id, { isStreaming: false });
+        }
+      }
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, []);
+
   // Sync active tab to backend when renderer switches tabs.
   useEffect(() => {
     if (activeTabId) {

--- a/src/renderer/src/components/settings/DesktopChangelog.tsx
+++ b/src/renderer/src/components/settings/DesktopChangelog.tsx
@@ -6,6 +6,24 @@ interface DesktopChangelogEntry {
 
 const CHANGELOG: DesktopChangelogEntry[] = [
   {
+    version: "0.5.6",
+    date: "2026-07-13",
+    sections: [
+      {
+        title: "Pi Routing fix",
+        items: [
+          "Fixed Pi Routing (Mixture of Agents) failing in the installed app with \"Could not locate pi-ai/compat\" — electron-builder flattens dependencies in the asar bundle, so the engine now checks both the flattened and nested layouts, and uses createRequire to load modules from inside the asar archive",
+        ],
+      },
+      {
+        title: "Streaming freeze fix",
+        items: [
+          "Fixed the UI freezing after a model finished its turn (\"Thinking...\" stuck, input disabled). The streaming indicator now resets on multiple redundant signals — message_end with a terminal stop reason, backend state events, and a 30-second watchdog — so a single missed event can never freeze the app permanently",
+        ],
+      },
+    ],
+  },
+  {
     version: "0.5.5",
     date: "2026-07-11",
     sections: [

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -346,8 +346,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     }),
 
   setTabPiState: (tabId, s) => {
-    // Never let state events override isStreaming.
-    const { isStreaming: _ignored, ...rest } = s as any;
+    // State events from the backend can carry isStreaming. We must NOT allow
+    // a stale state push to flip isStreaming back to true (agent_end is the
+    // authority for that). But we DO allow false through, so the backend can
+    // reset streaming when a turn ends — a critical fallback if agent_end is
+    // missed or delayed.
+    const incoming = s as any;
+    const allowStreamingReset = incoming.isStreaming === false;
+    const { isStreaming: _ignored, ...rest } = incoming;
+    if (allowStreamingReset) rest.isStreaming = false;
     set((st) => {
       const ts = st.tabStates[tabId];
       if (!ts) return {};
@@ -475,11 +482,18 @@ export const useAppStore = create<AppState>((set, get) => ({
         }
         case "message_end": {
           if (!event.message) break;
+          // If the assistant message ended with a terminal stop reason (not a
+          // tool-use, which continues the turn), reset isStreaming as a safety
+          // net. Normally agent_end handles this, but if agent_end is missed or
+          // delayed, this prevents the UI from freezing forever.
+          const stopReason = (event.message as any)?.stopReason;
+          const isTerminal = stopReason === "stop" || stopReason === "length" || stopReason === "content_filter";
           updated = {
             ...ts,
             messages: ts.messages.map((m) =>
               m.streaming ? { ...m, blocks: extractBlocks(event.message), streaming: false } : m,
             ),
+            ...(isTerminal ? { piState: { ...ts.piState, isStreaming: false } } : {}),
           };
           break;
         }


### PR DESCRIPTION
## v0.5.6 — Two critical fixes

### 1. Pi Routing (MOA) now works in the installed app
**Problem:** Pi Routing failed with "Could not locate @earendil-works/pi-ai/compat" in the packaged DMG, but worked fine in dev.

**Root cause:** electron-builder flattens npm dependencies inside the asar bundle. In dev, `pi-ai` lives nested under `pi-coding-agent/node_modules/`, but in the asar it's hoisted to the top-level `node_modules/`. The resolution logic only checked the nested path.

**Fix:** `resolveNestedCompat` now checks both layouts (flattened first, then nested). `getCompat` now uses `createRequire` instead of dynamic `import()` — Electron patches `require` for asar transparency, but Node's ESM loader doesn't understand the asar format.

This also fixes Tag Team's test runner, which delegates to the same `getCompat`.

### 2. UI no longer freezes after a model finishes
**Problem:** After a model completed its turn normally (`stopReason: "stop"`), the UI could freeze — "Thinking..." stuck, input disabled. Reproduced in an AgentMail coding session with `mimo-v2.5-pro`.

**Root cause:** `isStreaming: false` was set in exactly ONE place — the `agent_end` event handler — with no fallback. If `agent_end` was missed or delayed during heavy tool-call sequences, the UI froze forever. Worse, `setTabPiState` stripped `isStreaming` from ALL backend state events, so the `finally` block's `emitState()` was dead code.

**Fix (3 layers of defense):**
1. `message_end` now resets `isStreaming` when `stopReason` is terminal (`stop`/`length`/`content_filter`)
2. `setTabPiState` now allows `isStreaming: false` through from backend state events
3. Added a 30-second watchdog in `App.tsx` that polls `getState` and force-resets any stuck tab

### Files changed
- `src/main/moa/engine.ts` — dual-path compat resolution + createRequire
- `src/renderer/src/store/useAppStore.ts` — message_end streaming reset + setTabPiState fix
- `src/renderer/src/App.tsx` — streaming watchdog
- Changelogs + version bump to 0.5.6