### PR TITLE
feat: Mixture of Agents promoted to top-level sidebar item (v0.5.7)

### DIFF
--- a/docs/WEBSITE_CHANGELOG.md
+++ b/docs/WEBSITE_CHANGELOG.md
@@ -1,8 +1,15 @@
 # Pi Desktop — Website Changelog
 
 > **Source of truth for pi-desktop.dev.**
-> Current version: **v0.5.6** · Last updated: **July 13, 2026**
+> Current version: **v0.5.7** · Last updated: **July 13, 2026**
 > Copy directly into the website's changelog section.
+
+---
+
+## v0.5.7 — July 13, 2026
+
+### Sidebar
+- **Mixture of Agents (Pi Routing) is now a top-level sidebar item**, sitting right below Tag Team. It's no longer buried inside Settings — both multi-model features are now side by side where you expect them.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-desktop",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Pi Desktop - a full-featured macOS desktop app for the Pi coding agent",
   "main": "out/main/index.js",
   "author": "Pi Desktop",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -29,6 +29,9 @@ const PackagesView = lazy(() =>
 const TagTeamView = lazy(() =>
   import("./components/settings/TagTeamView").then((m) => ({ default: m.TagTeamView })),
 );
+const MoaView = lazy(() =>
+  import("./components/settings/MoaPanel").then((m) => ({ default: m.MoaPanel })),
+);
 
 export default function App() {
   const activeView = useAppStore((s) => s.activeView);
@@ -330,6 +333,16 @@ export default function App() {
             {activeView === "tagteam" && (
               <Suspense fallback={null}>
                 <TagTeamView />
+              </Suspense>
+            )}
+            {activeView === "moa" && (
+              <Suspense fallback={null}>
+                <div className="flex h-full flex-col">
+                  <div className="drag-region h-14 shrink-0" />
+                  <div className="flex-1 overflow-y-auto px-6 pb-6">
+                    <MoaView />
+                  </div>
+                </div>
               </Suspense>
             )}
             {activeView === "panel" && <PanelView panel={panels.find((p) => p.id === activePanelId)} />}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "../store/useAppStore";
-import { ChatIcon, SessionsIcon, ModelIcon, SettingsIcon, ExtensionsIcon, PackagesIcon, PlusIcon, PiLogoIcon, FolderIcon, TagTeamIcon } from "./Icons";
+import { ChatIcon, SessionsIcon, ModelIcon, SettingsIcon, ExtensionsIcon, PackagesIcon, PlusIcon, PiLogoIcon, FolderIcon, TagTeamIcon, PiRoutingIcon } from "./Icons";
 import type { View } from "../store/useAppStore";
 
 const NAV_ITEMS: { id: View | "sessions"; label: string; Icon: React.FC<{ size?: number; className?: string }> }[] = [
@@ -7,6 +7,7 @@ const NAV_ITEMS: { id: View | "sessions"; label: string; Icon: React.FC<{ size?:
   { id: "sessions", label: "Sessions", Icon: SessionsIcon },
   { id: "model", label: "Model", Icon: ModelIcon },
   { id: "tagteam", label: "Tag Team", Icon: TagTeamIcon },
+  { id: "moa", label: "Mixture of Agents", Icon: PiRoutingIcon },
   { id: "extensions", label: "Extensions", Icon: ExtensionsIcon },
   { id: "packages", label: "Packages", Icon: PackagesIcon },
   { id: "settings", label: "Settings", Icon: SettingsIcon },

--- a/src/renderer/src/components/settings/DesktopChangelog.tsx
+++ b/src/renderer/src/components/settings/DesktopChangelog.tsx
@@ -6,6 +6,18 @@ interface DesktopChangelogEntry {
 
 const CHANGELOG: DesktopChangelogEntry[] = [
   {
+    version: "0.5.7",
+    date: "2026-07-13",
+    sections: [
+      {
+        title: "Sidebar",
+        items: [
+          "Mixture of Agents (Pi Routing) is now a top-level sidebar item, right below Tag Team — no longer buried in Settings",
+        ],
+      },
+    ],
+  },
+  {
     version: "0.5.6",
     date: "2026-07-13",
     sections: [

--- a/src/renderer/src/components/settings/SettingsView.tsx
+++ b/src/renderer/src/components/settings/SettingsView.tsx
@@ -4,7 +4,6 @@ import { GitHubIcon } from "../GitHubBadge";
 import { PiChangelog } from "./PiChangelog";
 import { DesktopChangelog } from "./DesktopChangelog";
 import { SystemPanel } from "./SystemPanel";
-import { MoaPanel } from "./MoaPanel";
 
 interface AuthStatus {
   provider: string;
@@ -21,7 +20,7 @@ interface GitHubAuth {
   error?: string;
 }
 
-type SettingsTab = "settings" | "system" | "moa" | "desktop-changelog" | "pi-changelog";
+type SettingsTab = "settings" | "system" | "desktop-changelog" | "pi-changelog";
 
 export function SettingsView() {
   const [tab, setTab] = useState<SettingsTab>("settings");
@@ -36,9 +35,6 @@ export function SettingsView() {
         <SettingsTabButton active={tab === "system"} onClick={() => setTab("system")}>
           System
         </SettingsTabButton>
-        <SettingsTabButton active={tab === "moa"} onClick={() => setTab("moa")}>
-          Mixture of Agents
-        </SettingsTabButton>
         <SettingsTabButton active={tab === "desktop-changelog"} onClick={() => setTab("desktop-changelog")}>
           Desktop Changelog
         </SettingsTabButton>
@@ -49,7 +45,6 @@ export function SettingsView() {
       <div className="flex-1 overflow-y-auto px-6 pb-6 pt-4">
         {tab === "settings" && <SettingsPanel />}
         {tab === "system" && <SystemPanel />}
-        {tab === "moa" && <MoaPanel />}
         {tab === "desktop-changelog" && <DesktopChangelog />}
         {tab === "pi-changelog" && <PiChangelog />}
       </div>

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -67,7 +67,7 @@ export interface QueueState {
   followUp: string[];
 }
 
-export type View = "chat" | "model" | "settings" | "extensions" | "packages" | "tagteam" | "panel";
+export type View = "chat" | "model" | "settings" | "extensions" | "packages" | "tagteam" | "moa" | "panel";
 
 export interface ExtWidget {
   lines: string[];


### PR DESCRIPTION
MOA (Pi Routing) is now a top-level sidebar nav item, right below Tag Team. Removed from Settings tabs. Both multi-model features are now side by side.