### PR TITLE
feat: Pi Routing visibility — per-agent reports + branded indicator (v0.5.8)

### DIFF
--- a/docs/WEBSITE_CHANGELOG.md
+++ b/docs/WEBSITE_CHANGELOG.md
@@ -1,8 +1,17 @@
 # Pi Desktop — Website Changelog
 
 > **Source of truth for pi-desktop.dev.**
-> Current version: **v0.5.7** · Last updated: **July 13, 2026**
+> Current version: **v0.5.8** · Last updated: **July 13, 2026**
 > Copy directly into the website's changelog section.
+
+---
+
+## v0.5.8 — July 13, 2026
+
+### Pi Routing — now you can see what each agent said
+- **Per-agent report card.** After every Pi Routing run, a collapsible card appears in the chat showing each team member's full response, confidence score, and the synthesized briefing. Expand individual agents or everything at once — full transparency into what your multi-agent team contributed.
+- **Real-time per-agent progress.** Instead of a generic "Consulting 3 models…" you now see which models have finished ("2/3 models responded") as each one completes.
+- **Branded status bar indicator.** The bottom-right of the window shows the Pi Routing icon in the app brand color with live progress while routing, and the confidence score after completion. The tab bar also gets a pulsing routing icon so you can instantly spot which tab is running multi-agent work.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "Pi Desktop - a full-featured macOS desktop app for the Pi coding agent",
   "main": "out/main/index.js",
   "author": "Pi Desktop",

--- a/src/main/moa/engine.ts
+++ b/src/main/moa/engine.ts
@@ -77,7 +77,15 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
     message: `Consulting ${team.members.length} models…`,
   });
 
-  let memberResults = await fanOut(team.members, llmMessages, modelRegistry, signal);
+  let memberResults = await fanOut(team.members, llmMessages, modelRegistry, signal, (done, total, modelName) => {
+    onProgress?.({
+      phase: "member-done",
+      layer: 1,
+      member: modelName,
+      progress: 10 + Math.round((done / total) * 35),
+      message: `${done}/${total} models responded`,
+    });
+  });
 
   if (!memberResults.some((result) => result.response?.trim())) {
     const reasons = memberResults
@@ -202,7 +210,11 @@ async function fanOut(
   llmMessages: any[],
   modelRegistry: ModelRegistry,
   signal?: AbortSignal,
+  onMemberDone?: (doneCount: number, total: number, modelName: string) => void,
 ): Promise<MoaMemberResult[]> {
+  let doneCount = 0;
+  const total = members.length;
+
   const results = await Promise.allSettled(
     members.map(async (member) => {
       const model = resolveModel(modelRegistry, member.provider, member.modelId);
@@ -222,7 +234,13 @@ async function fanOut(
         signal,
       });
 
-      return extractText(response);
+      const text = extractText(response);
+      // Emit per-member progress as each model finishes.
+      doneCount++;
+      const modelName =
+        modelRegistry?.find?.(member.provider, member.modelId)?.name ?? member.modelId;
+      onMemberDone?.(doneCount, total, modelName);
+      return text;
     }),
   );
 

--- a/src/main/moa/types.ts
+++ b/src/main/moa/types.ts
@@ -74,7 +74,7 @@ export interface MoaResult {
 
 /** Progress event emitted during MOA execution. */
 export interface MoaProgressEvent {
-  phase: "fanning-out" | "aggregating" | "scoring" | "re-querying" | "done" | "error";
+  phase: "fanning-out" | "member-done" | "aggregating" | "scoring" | "re-querying" | "done" | "error";
   layer: number;
   member?: string;
   progress: number; // 0–100

--- a/src/main/pi/PiSessionManager.ts
+++ b/src/main/pi/PiSessionManager.ts
@@ -774,6 +774,17 @@ export class PiSessionManager {
       this.DIAG_EVENT,
       `Pi Routing complete: ${result.teamName} · ${result.layers} layer(s) · ${confidenceLabel}`,
     );
+
+    // Emit the full result to the renderer so it can show a post-completion
+    // report card with each team member's response, score, and the briefing.
+    this.events.emit(this.EXT_UI_EVENT, {
+      type: "moa:result",
+      teamName: result.teamName,
+      briefing: result.briefing,
+      teamResponses: result.teamResponses,
+      layers: result.layers,
+      confidence: result.confidence,
+    });
   }
 
   /**

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useAppStore } from "../store/useAppStore";
 import { GitRepoBadge } from "./GitRepoBadge";
 import { ExtensionStatusBadges } from "./extensions/ExtensionUi";
+import { PiRoutingIcon } from "./Icons";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
@@ -15,6 +16,7 @@ interface ModelInfo {
 
 export function StatusBar() {
   const piState = useAppStore((s) => s.activeTab.piState);
+  const moaActivity = useAppStore((s) => s.activeTab.moaActivity);
   const setPiState = (s: any) => {
     const tid = useAppStore.getState().activeTabId;
     if (tid) useAppStore.getState().setTabPiState(tid, s);
@@ -234,7 +236,24 @@ export function StatusBar() {
           )}
         </div>
 
-        <span className="text-text-faint">Pi Desktop</span>
+        {/* MOA branded indicator — replaces "Pi Desktop" when Pi Routing is active */}
+        {moaActivity && moaActivity.phase !== "complete" ? (
+          <span className="flex items-center gap-1.5 text-accent animate-pulse-subtle">
+            <PiRoutingIcon size={11} />
+            <span className="text-[11px] font-medium">
+              {moaActivity.message ?? "Pi Routing…"}
+            </span>
+          </span>
+        ) : moaActivity?.phase === "complete" && moaActivity.result ? (
+          <span className="flex items-center gap-1.5 text-accent">
+            <PiRoutingIcon size={11} />
+            <span className="text-[11px] font-medium">
+              Pi Routing · {moaActivity.result.confidence != null ? `${moaActivity.result.confidence}/10` : "complete"}
+            </span>
+          </span>
+        ) : (
+          <span className="text-text-faint">Pi Desktop</span>
+        )}
       </div>
     </footer>
   );

--- a/src/renderer/src/components/TabBar.tsx
+++ b/src/renderer/src/components/TabBar.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "../store/useAppStore";
-import { PlusIcon, FolderIcon } from "./Icons";
+import { PlusIcon, FolderIcon, PiRoutingIcon } from "./Icons";
 import { GitDirtyDot } from "./GitRepoBadge";
 
 export function TabBar() {
@@ -34,6 +34,7 @@ export function TabBar() {
         const active = tab.id === activeTabId;
         const ts = tabStates[tab.id];
         const isStreaming = ts?.piState?.isStreaming;
+        const moaActive = ts?.moaActivity && ts.moaActivity.phase !== "complete";
         return (
           <div
             key={tab.id}
@@ -57,6 +58,10 @@ export function TabBar() {
             <div className="relative flex items-center gap-1.5" style={{ zIndex: 1 }}>
               {isStreaming && (
                 <span className="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-accent" />
+              )}
+              {/* Pi Routing (MOA) active on this tab — show the routing icon */}
+              {moaActive && (
+                <PiRoutingIcon size={10} className="animate-pulse-subtle text-accent" />
               )}
               <FolderIcon size={11} className="text-text-faint" />
               {active && tab.cwd && <GitDirtyDot cwd={tab.cwd} tabId={tab.id} />}

--- a/src/renderer/src/components/chat/ChatView.tsx
+++ b/src/renderer/src/components/chat/ChatView.tsx
@@ -7,6 +7,7 @@ import { QueueChips } from "./QueueChips";
 import { ExtensionWidgets } from "../extensions/ExtensionUi";
 import { PiLogoIcon, FolderIcon } from "../Icons";
 import { PiRoutingIcon, TagTeamIcon } from "../Icons";
+import { MoaReportCard } from "./MoaReportCard";
 
 export function ChatView() {
   // Select only the fields this component uses, so unrelated tab state changes
@@ -17,6 +18,8 @@ export function ChatView() {
   const isStreaming = useAppStore((s) => s.activeTab.piState.isStreaming);
   const cwd = useAppStore((s) => s.activeTab.piState.cwd);
   const activeTabId = useAppStore((s) => s.activeTab.id);
+  const moaActivity = useAppStore((s) => s.activeTab.moaActivity);
+  const setTabMoaActivity = useAppStore((s) => s.setTabMoaActivity);
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   // Whether the viewport is pinned to the bottom (auto-following streaming
@@ -24,11 +27,6 @@ export function ChatView() {
   // so a token arriving while the user scrolled up never yanks the view back.
   const atBottomRef = useRef(true);
   const [showJump, setShowJump] = useState(false);
-  const [moaProgress, setMoaProgress] = useState<{
-    tabId: string;
-    phase: string;
-    message?: string;
-  } | null>(null);
   const [tagTeamHandoff, setTagTeamHandoff] = useState<{
     tabId: string;
     fromModel: string;
@@ -37,31 +35,60 @@ export function ChatView() {
   } | null>(null);
   const handoffTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Listen for MOA (Pi Routing) progress events + Tag Team handoff events.
+  // Listen for MOA (Pi Routing) progress/result events + Tag Team handoff.
+  // MOA events are routed into the global store (moaActivity) so StatusBar
+  // and TabBar can also react — they read from the store, not local state.
   useEffect(() => {
     const off = window.pi.events.onExtUi((message: any) => {
+      const eventTabId = message?.tabId as string | undefined;
+
       if (message?.type === "moa:progress") {
-        const eventTabId = message.tabId as string | undefined;
         if (!eventTabId) return;
         if (message.phase === "done" || message.phase === "error") {
-          setMoaProgress((current) => (current?.tabId === eventTabId ? null : current));
+          // Don't clear immediately — the moa:result event (next) carries the
+          // full result. Clear only the progress phase; the result persists.
+          useAppStore.getState().setTabMoaActivity(eventTabId, (prev) => ({
+            phase: "done",
+            message: prev?.message,
+            membersDone: prev?.membersDone,
+            membersTotal: prev?.membersTotal,
+            result: prev?.result,
+          }));
         } else {
-          setMoaProgress({
-            tabId: eventTabId,
+          const done = message.phase === "member-done";
+          const membersDone = done
+            ? (useAppStore.getState().tabStates[eventTabId]?.moaActivity?.membersDone ?? 0) + 1
+            : useAppStore.getState().tabStates[eventTabId]?.moaActivity?.membersDone;
+          const membersTotal = useAppStore.getState().tabStates[eventTabId]?.moaActivity?.membersTotal;
+          useAppStore.getState().setTabMoaActivity(eventTabId, {
             phase: message.phase,
             message: message.message,
+            member: message.member,
+            membersDone,
+            membersTotal,
           });
         }
-      } else if (message?.type === "tagteam:handoff") {
-        const eventTabId = (message.toTabId ?? message.tabId) as string | undefined;
+      } else if (message?.type === "moa:result") {
         if (!eventTabId) return;
+        useAppStore.getState().setTabMoaActivity(eventTabId, {
+          phase: "complete",
+          result: {
+            teamName: message.teamName,
+            briefing: message.briefing,
+            teamResponses: message.teamResponses,
+            layers: message.layers,
+            confidence: message.confidence,
+          },
+        });
+      } else if (message?.type === "tagteam:handoff") {
+        const handoffTabId = (message.toTabId ?? eventTabId) as string | undefined;
+        if (!handoffTabId) return;
         setTagTeamHandoff({
-          tabId: eventTabId,
+          tabId: handoffTabId,
           fromModel: message.fromModel ?? "Model A",
           toModel: message.toModel ?? "Model B",
           teamName: message.teamName ?? "Tag Team",
         });
-        // Auto-clear after 8 seconds — the indicator is transient.
         if (handoffTimerRef.current) clearTimeout(handoffTimerRef.current);
         handoffTimerRef.current = setTimeout(() => {
           handoffTimerRef.current = null;
@@ -123,6 +150,19 @@ export function ChatView() {
         </button>
       )}
 
+      {/* MOA report card — shows after Pi Routing completes, before the main model responds */}
+      {moaActivity?.result && moaActivity.phase === "complete" && (
+        <div className="px-[var(--msg-pad-x)]">
+          <MoaReportCard
+            teamName={moaActivity.result.teamName}
+            briefing={moaActivity.result.briefing}
+            teamResponses={moaActivity.result.teamResponses}
+            layers={moaActivity.result.layers}
+            confidence={moaActivity.result.confidence}
+          />
+        </div>
+      )}
+
       {/* Messages */}
       <div className="relative flex-1 overflow-hidden">
         {isEmpty ? (
@@ -155,10 +195,10 @@ export function ChatView() {
             components={{ Footer: () => <div className="h-6" /> }}
           />
         )}
-        {moaProgress?.tabId === activeTabId && (
+        {moaActivity && moaActivity.phase !== "complete" && moaActivity.phase !== "done" && (
           <div className="pointer-events-none absolute bottom-0 left-1/2 -translate-x-1/2 flex items-center gap-1.5 py-1 text-xs text-accent animate-pulse-subtle">
             <PiRoutingIcon size={12} />
-            {moaProgress.message ?? "Pi Routing…"}
+            {moaActivity.message ?? "Pi Routing…"}
           </div>
         )}
         {tagTeamHandoff?.tabId === activeTabId && (

--- a/src/renderer/src/components/chat/MoaReportCard.tsx
+++ b/src/renderer/src/components/chat/MoaReportCard.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { PiRoutingIcon } from "../Icons";
+
+interface MoaMemberResponse {
+  modelName: string;
+  role?: string;
+  response?: string;
+  error?: string;
+  score?: number;
+}
+
+/**
+ * Post-completion report card for Pi Routing (MOA). Shows each team member's
+ * response, score, and the synthesized briefing. Collapsible per-member.
+ *
+ * Rendered in the chat when a `moa:result` event arrives — gives the user full
+ * visibility into what each agent contributed.
+ */
+export function MoaReportCard({
+  teamName,
+  briefing,
+  teamResponses,
+  layers,
+  confidence,
+}: {
+  teamName: string;
+  briefing: string;
+  teamResponses: MoaMemberResponse[];
+  layers: number;
+  confidence: number | null;
+}) {
+  const [expandedMembers, setExpandedMembers] = useState<Set<number>>(new Set());
+  const [briefingExpanded, setBriefingExpanded] = useState(false);
+  const [allExpanded, setAllExpanded] = useState(false);
+
+  const toggleMember = (i: number) => {
+    setExpandedMembers((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (allExpanded) {
+      setExpandedMembers(new Set());
+      setBriefingExpanded(false);
+      setAllExpanded(false);
+    } else {
+      setExpandedMembers(new Set(teamResponses.map((_, i) => i)));
+      setBriefingExpanded(true);
+      setAllExpanded(true);
+    }
+  };
+
+  return (
+    <div className="my-2 rounded-xl border border-accent/30 bg-accent/5 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-accent/20">
+        <div className="flex items-center gap-2">
+          <PiRoutingIcon size={14} className="text-accent" />
+          <span className="text-xs font-semibold text-text">Pi Routing — {teamName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {confidence != null && (
+            <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${
+              confidence >= 6 ? "bg-success/20 text-success" : "bg-warning/20 text-warning"
+            }`}>
+              {confidence}/10
+            </span>
+          )}
+          {layers > 1 && (
+            <span className="rounded-full bg-bg-hover px-2 py-0.5 text-[10px] text-text-muted">
+              {layers} layers
+            </span>
+          )}
+          <button
+            onClick={toggleAll}
+            className="text-[10px] text-accent hover:text-accent-hover"
+          >
+            {allExpanded ? "Collapse all ▲" : "Expand all ▼"}
+          </button>
+        </div>
+      </div>
+
+      {/* Team member responses */}
+      <div className="divide-y divide-border/50">
+        {teamResponses.map((member, i) => (
+          <div key={i} className="px-4 py-2">
+            <button
+              onClick={() => toggleMember(i)}
+              className="flex w-full items-center justify-between text-left"
+            >
+              <div className="flex items-center gap-2">
+                <span className={`text-[11px] ${member.error ? "text-danger" : "text-success"}`}>
+                  {member.error ? "✕" : "✓"}
+                </span>
+                <span className="text-xs font-medium text-text">{member.modelName}</span>
+                {member.role && (
+                  <span className="rounded bg-bg-active px-1 py-0.5 text-[9px] uppercase tracking-wide text-text-faint">
+                    {member.role}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {member.score != null && (
+                  <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold ${
+                    member.score >= 6 ? "bg-success/20 text-success" : "bg-warning/20 text-warning"
+                  }`}>
+                    {member.score}/10
+                  </span>
+                )}
+                <span className="text-[10px] text-text-faint">
+                  {expandedMembers.has(i) ? "▲" : "▼"}
+                </span>
+              </div>
+            </button>
+            {expandedMembers.has(i) && (
+              <div className="mt-2 rounded-md border border-border bg-bg p-2.5">
+                {member.error ? (
+                  <p className="text-[11px] text-danger">{member.error}</p>
+                ) : (
+                  <pre className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed text-text-muted">
+                    {member.response || "(empty response)"}
+                  </pre>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Briefing */}
+      <div className="border-t border-accent/20 px-4 py-2.5">
+        <button
+          onClick={() => setBriefingExpanded((v) => !v)}
+          className="flex w-full items-center justify-between text-left"
+        >
+          <span className="text-[11px] font-semibold text-accent">Briefing</span>
+          <span className="text-[10px] text-text-faint">
+            {briefingExpanded ? "▲" : "▼"}
+          </span>
+        </button>
+        {briefingExpanded && (
+          <pre className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-border bg-bg p-2.5 text-[11px] leading-relaxed text-text-muted">
+            {briefing}
+          </pre>
+        )}
+        {!briefingExpanded && (
+          <p className="mt-1 line-clamp-2 text-[11px] text-text-faint">
+            {briefing.slice(0, 200)}…
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/components/settings/DesktopChangelog.tsx
+++ b/src/renderer/src/components/settings/DesktopChangelog.tsx
@@ -6,6 +6,21 @@ interface DesktopChangelogEntry {
 
 const CHANGELOG: DesktopChangelogEntry[] = [
   {
+    version: "0.5.8",
+    date: "2026-07-13",
+    sections: [
+      {
+        title: "Pi Routing visibility",
+        items: [
+          "See what each agent said — a collapsible report card now appears after every Pi Routing run, showing each team member's response, confidence score, and the synthesized briefing. Expand individual responses or all at once",
+          "Real-time per-agent progress — the engine now emits events as each model finishes, so you see \"2/3 models responded\" instead of a generic \"Consulting 3 models…\"",
+          "Branded status bar indicator — when Pi Routing is active, the bottom-right shows the routing icon in the app brand color with live progress (\"Pi Routing · 2/3 models ✓\"). After completion it shows the confidence score",
+          "Tab bar routing icon — tabs running a routed prompt now show the Pi Routing icon with a pulse animation, so you can instantly see which tab is doing multi-agent work",
+        ],
+      },
+    ],
+  },
+  {
     version: "0.5.7",
     date: "2026-07-13",
     sections: [

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -111,6 +111,33 @@ export interface ExtToast {
 
 export type TabMode = "chat" | "code";
 
+/**
+ * MOA (Pi Routing) activity state for a tab — drives the StatusBar indicator,
+ * TabBar icon, and post-completion report card. UI-only; not emitted by the
+ * backend (the backend emits `moa:progress` / `moa:result` ext-ui events that
+ * the renderer maps into this state).
+ */
+export interface MoaActivity {
+  /** Current phase: "fanning-out", "member-done", "aggregating", etc. */
+  phase: string;
+  /** Human-readable message, e.g. "2/3 models responded". */
+  message?: string;
+  /** How many team members have finished responding. */
+  membersDone?: number;
+  /** Total team members. */
+  membersTotal?: number;
+  /** Which member just completed (model name). */
+  member?: string;
+  /** Set when MOA completes — carries the full result for the report card. */
+  result?: {
+    teamName: string;
+    briefing: string;
+    teamResponses: { modelName: string; role?: string; response?: string; error?: string; score?: number }[];
+    layers: number;
+    confidence: number | null;
+  };
+}
+
 export interface TabState {
   id: string;
   title: string;
@@ -125,6 +152,8 @@ export interface TabState {
   extStatuses: Record<string, string>;
   /** Extension-driven widgets (banners), keyed by widget key. */
   extWidgets: Record<string, ExtWidget>;
+  /** MOA (Pi Routing) activity — null when MOA is not running on this tab. */
+  moaActivity?: MoaActivity | null;
 }
 
 export interface Tab {
@@ -198,6 +227,9 @@ interface AppState {
   // Per-tab state actions
   setTabPiState: (tabId: string, s: Partial<PiState>) => void;
   setTabQueue: (tabId: string, q: QueueState) => void;
+  /** Update MOA (Pi Routing) activity for a tab — drives StatusBar + report card.
+   *  Accepts either a value or an updater function (receives the current activity). */
+  setTabMoaActivity: (tabId: string, activity: MoaActivity | null | ((prev: MoaActivity | null) => MoaActivity | null)) => void;
   resetTabMessages: (tabId: string) => void;
   loadTabMessages: (tabId: string, rawMessages: any[]) => void;
   handleTabAgentEvent: (tabId: string, event: any) => void;
@@ -371,6 +403,18 @@ export const useAppStore = create<AppState>((set, get) => ({
       const ts = st.tabStates[tabId];
       if (!ts) return {};
       const updated = { ...ts, queue: q };
+      return {
+        tabStates: { ...st.tabStates, [tabId]: updated },
+        activeTab: st.activeTabId === tabId ? updated : st.activeTab,
+      };
+    }),
+
+  setTabMoaActivity: (tabId, activity) =>
+    set((st) => {
+      const ts = st.tabStates[tabId];
+      if (!ts) return {};
+      const resolved = typeof activity === "function" ? activity(ts.moaActivity ?? null) : activity;
+      const updated = { ...ts, moaActivity: resolved };
       return {
         tabStates: { ...st.tabStates, [tabId]: updated },
         activeTab: st.activeTabId === tabId ? updated : st.activeTab,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -599,7 +599,7 @@ export interface MoaResult {
 }
 
 export interface MoaProgressEvent {
-  phase: "fanning-out" | "aggregating" | "scoring" | "re-querying" | "done" | "error";
+  phase: "fanning-out" | "member-done" | "aggregating" | "scoring" | "re-querying" | "done" | "error";
   layer: number;
   member?: string;
   progress: number;


### PR DESCRIPTION
## v0.5.8 — Pi Routing visibility

### See what each agent said
A collapsible **report card** now appears after every Pi Routing run, showing:
- Each team member's full response (expandable)
- Per-member confidence scores (green ≥6, orange <6)
- The synthesized briefing
- "Expand all" / "Collapse all" controls

### Real-time per-agent progress
The engine now emits `member-done` events as each model finishes, so instead of a generic "Consulting 3 models…" you see **"2/3 models responded"** live.

### Branded status bar indicator
The bottom-right of the window now shows:
- **While routing:** `🔀 Pi Routing · 2/3 models ✓` in accent color with pulse
- **After completion:** `🔀 Pi Routing · 8/10` showing the confidence score
- **When idle:** `Pi Desktop` (unchanged)

### Tab bar routing icon
Tabs with active MOA show a pulsing Pi Routing icon so you can instantly spot which tab is doing multi-agent work.

### Files
- **NEW** `MoaReportCard.tsx` — collapsible post-completion report
- `engine.ts` — per-member progress emission in `fanOut()`
- `PiSessionManager.ts` — emit `moa:result` event with full result
- `useAppStore.ts` — `moaActivity` per-tab state (lifted from ChatView local)
- `ChatView.tsx` — wire events to store, render report card
- `StatusBar.tsx` — branded indicator
- `TabBar.tsx` — routing icon pulse