### PR TITLE
feat: session right-click + per-team Advanced mode + briefing visibility (v0.5.9)

### DIFF
--- a/docs/WEBSITE_CHANGELOG.md
+++ b/docs/WEBSITE_CHANGELOG.md
@@ -1,8 +1,16 @@
 # Pi Desktop — Website Changelog
 
 > **Source of truth for pi-desktop.dev.**
-> Current version: **v0.5.8** · Last updated: **July 13, 2026**
+> Current version: **v0.5.9** · Last updated: **July 13, 2026**
 > Copy directly into the website's changelog section.
+
+---
+
+## v0.5.9 — July 13, 2026
+
+### Sessions — right-click to manage
+- **Right-click any session** to favorite or delete it. The context menu appears at your cursor with "Add/Remove from Favorites" and "Delete Session" options.
+- Sessions belonging to a favorited folder now show a **star indicator** on the card so you can spot your favorites at a glance.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Pi Desktop - a full-featured macOS desktop app for the Pi coding agent",
   "main": "out/main/index.js",
   "author": "Pi Desktop",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -438,6 +438,15 @@ export function registerIpc(pool: SessionPool, getMainWindow: () => BrowserWindo
     const m = await mgr(a);
     return m.renameSession(a.name);
   });
+  handle("pi:session.delete", async (a) => {
+    try {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(a.file);
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
   handle("pi:session.exportHtml", async (a) => {
     const m = await mgr(a);
     return m.exportHtml(a?.outputPath);

--- a/src/main/moa/types.ts
+++ b/src/main/moa/types.ts
@@ -23,6 +23,8 @@ export interface MoaTeam {
   members: MoaMember[];
   /** The model that synthesizes member responses into a briefing. */
   aggregatorModel: { provider: string; modelId: string };
+  /** "basic" = single pass (default); "advanced" = score + re-query loop. */
+  mode?: "basic" | "advanced";
 }
 
 /** Advanced-mode tuning knobs. */

--- a/src/main/pi/PiSessionManager.ts
+++ b/src/main/pi/PiSessionManager.ts
@@ -732,7 +732,7 @@ export class PiSessionManager {
         team,
         modelRegistry: this.deps.modelRegistry,
         sessionMessages,
-        mode: config.defaultMode,
+        mode: team.mode ?? config.defaultMode,
         maxLayers: config.advanced.maxLayers,
         confidenceThreshold: config.advanced.confidenceThreshold,
         signal,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,6 +53,7 @@ const api = {
   getSessionTree: invoke("pi:session.tree"),
   getForkMessages: invoke("pi:session.forkMessages"),
   renameSession: invoke("pi:session.rename"),
+  deleteSession: invoke("pi:session.delete"),
   exportHtml: invoke("pi:session.exportHtml"),
   getMessages: invoke("pi:messages"),
   getState: invoke("pi:state"),

--- a/src/renderer/src/components/chat/MoaReportCard.tsx
+++ b/src/renderer/src/components/chat/MoaReportCard.tsx
@@ -30,7 +30,7 @@ export function MoaReportCard({
   confidence: number | null;
 }) {
   const [expandedMembers, setExpandedMembers] = useState<Set<number>>(new Set());
-  const [briefingExpanded, setBriefingExpanded] = useState(false);
+  const [briefingExpanded, setBriefingExpanded] = useState(true);
   const [allExpanded, setAllExpanded] = useState(false);
 
   const toggleMember = (i: number) => {
@@ -131,25 +131,27 @@ export function MoaReportCard({
         ))}
       </div>
 
-      {/* Briefing */}
-      <div className="border-t border-accent/20 px-4 py-2.5">
+      {/* Briefing — the key output: the synthesized analysis fed to the main model */}
+      <div className="border-t border-accent/20 px-4 py-3 bg-accent/5">
         <button
           onClick={() => setBriefingExpanded((v) => !v)}
           className="flex w-full items-center justify-between text-left"
         >
-          <span className="text-[11px] font-semibold text-accent">Briefing</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] font-bold text-accent">📝 Briefing</span>
+            <span className="text-[9px] text-text-faint">— what the main model received</span>
+          </div>
           <span className="text-[10px] text-text-faint">
             {briefingExpanded ? "▲" : "▼"}
           </span>
         </button>
-        {briefingExpanded && (
-          <pre className="mt-2 max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-border bg-bg p-2.5 text-[11px] leading-relaxed text-text-muted">
+        {briefingExpanded ? (
+          <pre className="mt-2 max-h-80 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-accent/20 bg-bg p-3 text-[11px] leading-relaxed text-text">
             {briefing}
           </pre>
-        )}
-        {!briefingExpanded && (
-          <p className="mt-1 line-clamp-2 text-[11px] text-text-faint">
-            {briefing.slice(0, 200)}…
+        ) : (
+          <p className="mt-1 line-clamp-1 text-[11px] text-text-faint">
+            {briefing.slice(0, 120)}…
           </p>
         )}
       </div>

--- a/src/renderer/src/components/sessions/SessionsView.tsx
+++ b/src/renderer/src/components/sessions/SessionsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useAppStore } from "../../store/useAppStore";
 import { PlusIcon, FolderIcon } from "../Icons";
 import { GitRepoHeader } from "../GitRepoBadge";
+import { FilePathMenu, type FilePathAction } from "../chat/FilePathMenu";
 
 interface SessionItem {
   id: string;
@@ -16,6 +17,7 @@ interface SessionItem {
 export function SessionsView() {
   const [sessions, setSessions] = useState<SessionItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; session: SessionItem } | null>(null);
   const addTab = useAppStore((s) => s.addTab);
   const focusExistingTab = useAppStore((s) => s.focusExistingTab);
   const favorites = useAppStore((s) => s.favorites);
@@ -193,6 +195,7 @@ export function SessionsView() {
                   <div className="space-y-1.5">
                     {dirSessions.map((s) => {
                       const isActive = s.file === activeSessionFile;
+                      const isFav = isFavorite(s.cwd || "");
                       return (
                         <button
                           key={s.id}
@@ -202,6 +205,11 @@ export function SessionsView() {
                             await window.pi.api.createTab({ tabId, cwd: s.cwd });
                             addTab({ id: tabId, title: s.cwd?.split("/").pop() || s.name || s.id.slice(0, 8), cwd: s.cwd });
                             await window.pi.api.switchSession({ sessionPath: s.file, cwd: s.cwd, tabId });
+                          }}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setContextMenu({ x: e.clientX, y: e.clientY, session: s });
                           }}
                           className={`no-drag flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left transition-all ${
                             isActive
@@ -223,13 +231,18 @@ export function SessionsView() {
                               )}
                             </div>
                           </div>
-                          {s.messageCount != null && (
-                            <span className={`ml-2 shrink-0 rounded-full px-1.5 py-0.5 text-[10px] ${
-                              isActive ? "bg-accent/20 text-accent" : "bg-bg-active text-text-faint"
-                            }`}>
-                              {s.messageCount}
-                            </span>
-                          )}
+                          <div className="ml-2 flex shrink-0 items-center gap-1">
+                            {isFav && (
+                              <StarIcon size={12} filled className="text-accent" />
+                            )}
+                            {s.messageCount != null && (
+                              <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${
+                                isActive ? "bg-accent/20 text-accent" : "bg-bg-active text-text-faint"
+                              }`}>
+                                {s.messageCount}
+                              </span>
+                            )}
+                          </div>
                         </button>
                       );
                     })}
@@ -240,6 +253,39 @@ export function SessionsView() {
           </div>
         )}
       </div>
+
+      {/* Right-click context menu */}
+      {contextMenu && (
+        <FilePathMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          actions={[
+            {
+              label: isFavorite(contextMenu.session.cwd || "")
+                ? "Remove from Favorites"
+                : "Add to Favorites",
+              onSelect: () => {
+                toggleFavorite(contextMenu.session.cwd || "");
+              },
+            },
+            {
+              label: "Delete Session",
+              onSelect: async () => {
+                const s = contextMenu.session;
+                try {
+                  const result = await window.pi.api.deleteSession({ file: s.file });
+                  if (result.success) {
+                    refresh();
+                  }
+                } catch (err) {
+                  console.error("[sessions] Failed to delete:", err);
+                }
+              },
+            },
+          ]}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/src/components/settings/DesktopChangelog.tsx
+++ b/src/renderer/src/components/settings/DesktopChangelog.tsx
@@ -6,6 +6,19 @@ interface DesktopChangelogEntry {
 
 const CHANGELOG: DesktopChangelogEntry[] = [
   {
+    version: "0.5.9",
+    date: "2026-07-13",
+    sections: [
+      {
+        title: "Sessions",
+        items: [
+          "Right-click any session to favorite or delete it — the context menu appears at the cursor with options to add/remove from Favorites and delete the session from disk",
+          "Sessions that belong to a favorited folder now show a star indicator on the card",
+        ],
+      },
+    ],
+  },
+  {
     version: "0.5.8",
     date: "2026-07-13",
     sections: [

--- a/src/renderer/src/components/settings/MoaPanel.tsx
+++ b/src/renderer/src/components/settings/MoaPanel.tsx
@@ -158,7 +158,12 @@ export function MoaPanel() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-text">{team.name}</div>
+                      <div className="flex items-center gap-2">
+                        <div className="truncate text-sm font-medium text-text">{team.name}</div>
+                        {team.mode === "advanced" && (
+                          <span className="rounded bg-accent/20 px-1 py-0.5 text-[9px] font-bold uppercase text-accent">Advanced</span>
+                        )}
+                      </div>
                       {/* Model chips — see the team's makeup at a glance */}
                       <div className="mt-1.5 flex flex-wrap gap-1">
                         {memberNames.map((name, i) => (
@@ -514,6 +519,34 @@ function TeamEditor({
             </div>
             <p className="mt-1 text-[10px] text-text-faint">
               The aggregator synthesizes team responses into a briefing for the main model.
+            </p>
+          </div>
+
+          {/* Mode toggle — Basic vs Advanced */}
+          <div>
+            <label className="mb-1 block text-xs text-text-muted">Mode</label>
+            <div className="flex gap-1 rounded-lg border border-border bg-bg-subtle p-0.5">
+              <button
+                onClick={() => setDraft({ ...draft, mode: "basic" })}
+                className={`flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  (draft.mode ?? "basic") === "basic" ? "bg-bg-active text-text" : "text-text-faint hover:text-text-muted"
+                }`}
+              >
+                Basic
+              </button>
+              <button
+                onClick={() => setDraft({ ...draft, mode: "advanced" })}
+                className={`flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                  draft.mode === "advanced" ? "bg-bg-active text-text" : "text-text-faint hover:text-text-muted"
+                }`}
+              >
+                Advanced
+              </button>
+            </div>
+            <p className="mt-1 text-[10px] text-text-faint">
+              {(draft.mode ?? "basic") === "basic"
+                ? "Single pass — team members respond once, the aggregator synthesizes a briefing."
+                : "Score + re-query — the aggregator scores each response (0–10) and re-queries low-scoring members with feedback for a refined result. Uses the global max layers and threshold settings."}
             </p>
           </div>
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -270,6 +270,7 @@ export interface PiApi {
     tabId?: string;
   }) => Promise<{ messages: { entryId: string; text: string }[] }>;
   renameSession: (args: { name: string; tabId?: string }) => Promise<{ success: boolean }>;
+  deleteSession: (args: { file: string; tabId?: string }) => Promise<{ success: boolean; error?: string }>;
   exportHtml: (args?: { outputPath?: string; tabId?: string }) => Promise<{ path: string }>;
   getMessages: (args?: { tabId?: string }) => Promise<unknown>;
   getState: (args?: { tabId?: string }) => Promise<PiState>;
@@ -565,6 +566,8 @@ export interface MoaTeam {
   name: string;
   members: MoaMember[];
   aggregatorModel: { provider: string; modelId: string };
+  /** "basic" = single pass (default); "advanced" = score + re-query loop. */
+  mode?: "basic" | "advanced";
 }
 
 export interface MoaAdvancedConfig {


### PR DESCRIPTION
## v0.5.9 — Three upgrades

### Sessions — right-click to manage
- **Right-click any session** for a context menu with "Add/Remove from Favorites" and "Delete Session"
- Favorited sessions show a **star indicator** on the card
- New `pi:session.delete` IPC deletes the JSONL file from disk

### Pi Routing — per-team Advanced mode
- Each team now has its own **Basic/Advanced toggle** in the team editor (was a single global setting)
- Basic = single pass; Advanced = score + re-query loop with the global threshold/layers settings
- Team cards show an "Advanced" badge when applicable

### Briefing — now visible by default
- The briefing section auto-expands with prominent styling (accent background, bold label, "what the main model received" subtitle)
- The user said they couldn't see the briefing — it was collapsed by default with just a truncated preview