### PR TITLE
Migrate to Pi SDK 0.80.10 (ModelRuntime)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "pi-desktop",
-  "version": "0.5.6",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-desktop",
-      "version": "0.5.6",
+      "version": "0.5.9",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.80.6",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
         "@esbuild/darwin-arm64": "^0.28.1",
         "@types/react-syntax-highlighter": "^15.5.13",
         "react-markdown": "^10.1.0",
@@ -366,15 +366,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -837,11 +837,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -851,8 +851,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -875,8 +875,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -7450,7 +7450,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.6",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
     "@esbuild/darwin-arm64": "^0.28.1",
     "@types/react-syntax-highlighter": "^15.5.13",
     "react-markdown": "^10.1.0",

--- a/src/main/moa/engine.ts
+++ b/src/main/moa/engine.ts
@@ -4,13 +4,12 @@
  * Orchestrates fan-out to team models in parallel, aggregates their responses,
  * and (in advanced mode) scores + re-queries low-confidence responses.
  *
- * Uses the Pi SDK's `completeSimple` for standalone model calls (no agent loop),
- * and `convertToLlm` to convert the session's agent messages into LLM format.
+ * Uses the shared ModelRuntime's `completeSimple` for standalone model calls
+ * (no agent loop; auth is resolved internally by the runtime), and
+ * `convertToLlm` to convert the session's agent messages into LLM format.
  */
 
-import { pathToFileURL, fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import { existsSync } from "node:fs";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { MoaTeam, MoaMemberResult, MoaResult, MoaProgressEvent } from "./types";
 import { memberSystemPrompt, aggregatorSystemPrompt, reQueryPrompt } from "./prompts";
 
@@ -20,7 +19,6 @@ async function getSdk() {
 }
 
 // Types from the SDK (lazily resolved at call time).
-type ModelRegistry = any;
 type Model = any;
 type Context = any;
 type AssistantMessage = any;
@@ -31,8 +29,8 @@ export interface RunMoaOptions {
   message: string;
   /** The team to use. */
   team: MoaTeam;
-  /** The live model registry (from PiSessionManager.deps). */
-  modelRegistry: ModelRegistry;
+  /** The shared model runtime (from PiSessionManager.deps). */
+  modelRuntime: ModelRuntime;
   /** Existing session messages for context. */
   sessionMessages: AgentMessage[];
   /** Basic = single pass; Advanced = score + re-query loop. */
@@ -54,7 +52,7 @@ export interface RunMoaOptions {
  * members fail (caller should catch and skip MOA enrichment in that case).
  */
 export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
-  const { message, team, modelRegistry, sessionMessages, mode, onProgress, signal } = opts;
+  const { message, team, modelRuntime, sessionMessages, mode, onProgress, signal } = opts;
   const maxLayers = opts.maxLayers ?? 3;
   const confidenceThreshold = opts.confidenceThreshold ?? 6;
 
@@ -77,7 +75,7 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
     message: `Consulting ${team.members.length} models…`,
   });
 
-  let memberResults = await fanOut(team.members, llmMessages, modelRegistry, signal, (done, total, modelName) => {
+  let memberResults = await fanOut(team.members, llmMessages, modelRuntime, signal, (done, total, modelName) => {
     onProgress?.({
       phase: "member-done",
       layer: 1,
@@ -107,7 +105,7 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
     message,
     memberResults,
     team.aggregatorModel,
-    modelRegistry,
+    modelRuntime,
     llmMessages,
     mode === "advanced",
     confidenceThreshold,
@@ -146,7 +144,7 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
       // Re-query the low-scoring members with refined prompts.
       const reQueried = await Promise.allSettled(
         lowScorers.map((r) =>
-          reQueryMember(r, message, aggregatorOutput.feedback, modelRegistry, signal),
+          reQueryMember(r, message, aggregatorOutput.feedback, modelRuntime, signal),
         ),
       );
 
@@ -167,7 +165,7 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
         message,
         memberResults,
         team.aggregatorModel,
-        modelRegistry,
+        modelRuntime,
         llmMessages,
         true,
         confidenceThreshold,
@@ -208,7 +206,7 @@ export async function runMoa(opts: RunMoaOptions): Promise<MoaResult> {
 async function fanOut(
   members: MoaTeam["members"],
   llmMessages: any[],
-  modelRegistry: ModelRegistry,
+  modelRuntime: ModelRuntime,
   signal?: AbortSignal,
   onMemberDone?: (doneCount: number, total: number, modelName: string) => void,
 ): Promise<MoaMemberResult[]> {
@@ -217,28 +215,22 @@ async function fanOut(
 
   const results = await Promise.allSettled(
     members.map(async (member) => {
-      const model = resolveModel(modelRegistry, member.provider, member.modelId);
+      const model = resolveModel(modelRuntime, member.provider, member.modelId);
       if (!model) throw new Error(`Model not found: ${member.provider}/${member.modelId}`);
-
-      const auth = await resolveAuth(modelRegistry, model);
-      if (!auth.ok) throw new Error(`No auth for ${member.provider}/${member.modelId}`);
 
       const context: Context = {
         systemPrompt: memberSystemPrompt(member.role),
         messages: llmMessages,
       };
 
-      const response = await completeSimple(model, context, {
-        apiKey: auth.apiKey,
-        headers: auth.headers,
-        signal,
-      });
+      // ModelRuntime resolves auth internally from the model's provider.
+      const response = await modelRuntime.completeSimple(model, context, { signal });
 
       const text = extractText(response);
       // Emit per-member progress as each model finishes.
       doneCount++;
       const modelName =
-        modelRegistry?.find?.(member.provider, member.modelId)?.name ?? member.modelId;
+        resolveModel(modelRuntime, member.provider, member.modelId)?.name ?? member.modelId;
       onMemberDone?.(doneCount, total, modelName);
       return text;
     }),
@@ -247,7 +239,7 @@ async function fanOut(
   return members.map((member, i) => {
     const result = results[i];
     const modelName =
-      modelRegistry?.find?.(member.provider, member.modelId)?.name ?? member.modelId;
+      resolveModel(modelRuntime, member.provider, member.modelId)?.name ?? member.modelId;
     if (result?.status === "fulfilled") {
       return {
         provider: member.provider,
@@ -307,21 +299,17 @@ async function aggregate(
   userMessage: string,
   memberResults: MoaMemberResult[],
   aggregatorSpec: { provider: string; modelId: string },
-  modelRegistry: ModelRegistry,
+  modelRuntime: ModelRuntime,
   llmMessages: any[],
   advanced: boolean,
   confidenceThreshold: number,
   signal?: AbortSignal,
 ): Promise<AggregatorOutput> {
-  const model = resolveModel(modelRegistry, aggregatorSpec.provider, aggregatorSpec.modelId);
+  const model = resolveModel(modelRuntime, aggregatorSpec.provider, aggregatorSpec.modelId);
   if (!model)
     throw new Error(
       `Aggregator model not found: ${aggregatorSpec.provider}/${aggregatorSpec.modelId}`,
     );
-
-  const auth = await resolveAuth(modelRegistry, model);
-  if (!auth.ok)
-    throw new Error(`No auth for aggregator ${aggregatorSpec.provider}/${aggregatorSpec.modelId}`);
 
   // Build the aggregator's context: the user's message + each member's response.
   const teamResponsesText = memberResults
@@ -345,11 +333,7 @@ ${aggregatorSystemPrompt(advanced, confidenceThreshold)}`;
     messages: [{ role: "user", content: aggregatorUserMessage }],
   };
 
-  const response = await completeSimple(model, context, {
-    apiKey: auth.apiKey,
-    headers: auth.headers,
-    signal,
-  });
+  const response = await modelRuntime.completeSimple(model, context, { signal });
 
   const text = extractText(response);
 
@@ -380,14 +364,11 @@ async function reQueryMember(
   member: MoaMemberResult,
   userMessage: string,
   feedback: string,
-  modelRegistry: ModelRegistry,
+  modelRuntime: ModelRuntime,
   signal?: AbortSignal,
 ): Promise<string | undefined> {
-  const model = resolveModel(modelRegistry, member.provider, member.modelId);
+  const model = resolveModel(modelRuntime, member.provider, member.modelId);
   if (!model) return undefined;
-
-  const auth = await resolveAuth(modelRegistry, model);
-  if (!auth.ok) return undefined;
 
   const context: Context = {
     systemPrompt: memberSystemPrompt(member.role),
@@ -399,11 +380,7 @@ async function reQueryMember(
     ],
   };
 
-  const response = await completeSimple(model, context, {
-    apiKey: auth.apiKey,
-    headers: auth.headers,
-    signal,
-  });
+  const response = await modelRuntime.completeSimple(model, context, { signal });
 
   return extractText(response);
 }
@@ -411,135 +388,15 @@ async function reQueryMember(
 // --- SDK helpers ---
 
 function resolveModel(
-  modelRegistry: ModelRegistry,
+  modelRuntime: ModelRuntime,
   provider: string,
   modelId: string,
 ): Model | undefined {
   try {
-    return modelRegistry?.find?.(provider, modelId) ?? undefined;
+    return modelRuntime?.getModel?.(provider, modelId) ?? undefined;
   } catch {
     return undefined;
   }
-}
-
-async function resolveAuth(
-  modelRegistry: ModelRegistry,
-  model: Model,
-): Promise<{ ok: boolean; apiKey?: string; headers?: Record<string, string> }> {
-  try {
-    const auth = await modelRegistry?.getApiKeyAndHeaders?.(model);
-    if (!auth?.ok) return { ok: false };
-    return { ok: true, apiKey: auth.apiKey, headers: auth.headers };
-  } catch {
-    return { ok: false };
-  }
-}
-
-// Cached compat module — resolved once, reused across all completeSimple calls.
-let compatModulePromise: Promise<any> | null = null;
-
-/**
- * Resolve the pi-ai/compat module on disk and import it via a file:// URL.
- *
- * Why this is non-trivial: `@earendil-works/pi-ai` is a NESTED dependency of
- * `@earendil-works/pi-coding-agent` (not a direct dep of this app). Its
- * package.json `exports` map only declares an ESM `import` condition for
- * "./compat" — so every standard resolution path fails:
- *   - bare `import("@earendil-works/pi-ai/compat")` → not in our deps
- *   - `import("…/node_modules/…/compat")`           → ERR_PACKAGE_PATH_NOT_EXPORTED
- *   - `require.resolve("@earendil-works/pi-ai/compat")` from within the
- *     agent package → no `require` condition in the exports map
- *
- * The escape hatch: locate pi-coding-agent's package directory on disk, then
- * directly import its nested pi-ai/dist/compat.js by absolute file path. This
- * bypasses the exports map entirely (Node allows direct file imports) and
- * works identically in dev and inside the packaged asar bundle.
- */
-export async function getCompat(): Promise<any> {
-  if (!compatModulePromise) {
-    compatModulePromise = (async () => {
-      // import.meta.url is the ESM-safe base. Bundled output is a file:// URL
-      // under the app; falling back to cwd covers any CJS edge case.
-      const here = (import.meta as any).url ?? pathToFileURL(process.cwd() + "/").href;
-      const compatFile = resolveNestedCompat(here);
-
-      // Dynamic import() does NOT work for files packed inside an asar archive
-      // because Node's ESM loader doesn't understand the asar format. Electron
-      // patches require() (and by extension createRequire) to handle asar
-      // transparently. So we try require first, then fall back to import for
-      // dev mode where the file is a regular .js on disk.
-      try {
-        const { createRequire } = await import("node:module");
-        const req = createRequire(here);
-        return req(compatFile);
-      } catch {
-        // Dev mode or unpacked file — ESM import works here.
-        return await import(pathToFileURL(compatFile).href);
-      }
-    })();
-  }
-  return compatModulePromise;
-}
-
-/**
- * Walk up from `fromUrl` looking for the pi-ai compat module.
- *
- * Checks two layouts on every directory level:
- * 1. FLATTENED: `node_modules/@earendil-works/pi-ai/dist/compat.js`
- *    This is what electron-builder produces in the asar — it hoists nested
- *    deps to the top level.
- * 2. NESTED: `node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/compat.js`
- *    This is what npm produces in dev — pi-ai is a nested dep of pi-coding-agent.
- *
- * Without checking both, MOA works in dev but fails in the packaged app
- * (or vice versa).
- */
-function resolveNestedCompat(fromUrl: string): string {
-  let dir = dirname(fileURLToPath(fromUrl));
-  for (let i = 0; i < 20; i++) {
-    if (!dir || dir === dirname(dir)) break;
-
-    // 1. Flattened layout (asar / production).
-    const flatCompat = join(
-      dir,
-      "node_modules",
-      "@earendil-works",
-      "pi-ai",
-      "dist",
-      "compat.js",
-    );
-    if (existsSync(flatCompat)) return flatCompat;
-
-    // 2. Nested layout (npm dev install).
-    const nestedCompat = join(
-      dir,
-      "node_modules",
-      "@earendil-works",
-      "pi-coding-agent",
-      "node_modules",
-      "@earendil-works",
-      "pi-ai",
-      "dist",
-      "compat.js",
-    );
-    if (existsSync(nestedCompat)) return nestedCompat;
-
-    dir = dirname(dir);
-  }
-  throw new Error(
-    "Could not locate @earendil-works/pi-ai/compat — is @earendil-works/pi-coding-agent installed?",
-  );
-}
-
-async function completeSimple(
-  model: Model,
-  context: Context,
-  options: any,
-): Promise<AssistantMessage> {
-  const piAi = await getCompat();
-  const complete = (piAi as any).completeSimple ?? (piAi as any).complete;
-  if (!complete) throw new Error("completeSimple not found in pi-ai/compat");
-  return complete(model, context, options);
 }
 
 function extractText(message: AssistantMessage): string {

--- a/src/main/pi/PiSessionManager.ts
+++ b/src/main/pi/PiSessionManager.ts
@@ -16,8 +16,7 @@ import type {
   AgentSession,
   AgentSessionEvent,
   AgentSessionRuntime,
-  AuthStorage,
-  ModelRegistry,
+  ModelRuntime,
   SessionManager as PiSessionManagerType,
   SettingsManager as PiSettingsManagerType,
 } from "@earendil-works/pi-coding-agent";
@@ -82,8 +81,7 @@ function applyHttpProxySettings(httpProxy: string | undefined): void {
 }
 
 export interface PiManagerDeps {
-  authStorage: AuthStorage;
-  modelRegistry: ModelRegistry;
+  modelRuntime: ModelRuntime;
   settingsManager: PiSettingsManagerType;
 }
 
@@ -415,18 +413,17 @@ export class PiSessionManager {
     applyHttpProxySettings((bootstrapSettings as any).getGlobalSettings?.()?.httpProxy);
     configureHttpDispatcher();
 
-    // Use shared deps cache - avoids recreating AuthStorage/ModelRegistry/SettingsManager per tab.
+    // Use shared deps cache - avoids recreating ModelRuntime/SettingsManager per tab.
     const shared = await getSharedDeps(this.agentDir, pi, this.cwd);
     this._deps = {
-      authStorage: shared.authStorage,
-      modelRegistry: shared.modelRegistry,
+      modelRuntime: shared.modelRuntime,
       settingsManager: shared.settingsManager,
     };
 
     await this.buildRuntime(pi, this.cwd, pi.SessionManager.create(this.cwd));
-    // Ensure every custom provider's key is in authStorage from the start, so
-    // model selection works without depending on which registry instance is hit.
-    this.registerCustomProviderKeys();
+    // Ensure every custom provider's key is registered in the model runtime from
+    // the start, so model selection works immediately.
+    await this.registerCustomProviderKeys();
     this.initialized = true;
   }
 
@@ -440,13 +437,11 @@ export class PiSessionManager {
       const services = await pi.createAgentSessionServices({
         cwd,
         agentDir: this.agentDir,
-        authStorage: this._deps?.authStorage,
+        modelRuntime: this._deps?.modelRuntime,
         settingsManager: this._deps?.settingsManager,
       });
-      // Update modelRegistry after services loads custom models from models.json
-      if (this._deps && services.modelRegistry) {
-        this._deps.modelRegistry = services.modelRegistry;
-      }
+      // The shared modelRuntime is passed in above, so services.modelRuntime is
+      // the same instance — no re-bind needed (it already knows custom models).
       // Register our native headless web_search ONLY when the pi-web-access
       // package isn't installed — that package's richer web_search takes priority.
       const customTools = this.isWebAccessInstalled() ? undefined : [createNativeWebSearchTool()];
@@ -715,7 +710,7 @@ export class PiSessionManager {
    * injectWebNudge.
    */
   private async runMoaEnrichment(message: string, signal?: AbortSignal): Promise<void> {
-    if (!this.session || !this.routingTeamId || !this.deps?.modelRegistry) return;
+    if (!this.session || !this.routingTeamId || !this.deps?.modelRuntime) return;
 
     const { runMoa } = await import("../moa/engine");
     const config = loadMoaConfig();
@@ -730,7 +725,7 @@ export class PiSessionManager {
       result = await runMoa({
         message,
         team,
-        modelRegistry: this.deps.modelRegistry,
+        modelRuntime: this.deps.modelRuntime,
         sessionMessages,
         mode: team.mode ?? config.defaultMode,
         maxLayers: config.advanced.maxLayers,
@@ -796,13 +791,13 @@ export class PiSessionManager {
    * in-memory draft.
    */
   async runMoaTest(message: string, team: any, modeOverride?: "basic" | "advanced"): Promise<any> {
-    if (!this.deps?.modelRegistry) throw new Error("Model registry not available");
+    if (!this.deps?.modelRuntime) throw new Error("Model runtime not available");
     const { runMoa } = await import("../moa/engine");
     const config = loadMoaConfig();
     return runMoa({
       message,
       team,
-      modelRegistry: this.deps.modelRegistry,
+      modelRuntime: this.deps.modelRuntime,
       sessionMessages: this.session?.messages ?? [],
       mode: modeOverride ?? config.defaultMode,
       maxLayers: config.advanced.maxLayers,
@@ -818,7 +813,7 @@ export class PiSessionManager {
    * until the final stage, which has no successor and ends the chain.
    */
   private async runTagTeamHandoff(): Promise<void> {
-    if (!this.session || !this.tagTeamTeamId || !this.deps?.modelRegistry) return;
+    if (!this.session || !this.tagTeamTeamId || !this.deps?.modelRuntime) return;
     if (!this.tagTeamHandoffCallback) {
       this.events.emit(this.DIAG_EVENT, "Tag Team: tab creation not available. Skipping handoff.");
       return;
@@ -846,10 +841,10 @@ export class PiSessionManager {
     if (!previousOutput) return;
 
     const fromModelName =
-      this.deps.modelRegistry.find(currentStage.provider, currentStage.modelId)?.name ??
+      this.deps.modelRuntime.getModel(currentStage.provider, currentStage.modelId)?.name ??
       currentStage.modelId;
     const toModelName =
-      this.deps.modelRegistry.find(nextStage.provider, nextStage.modelId)?.name ??
+      this.deps.modelRuntime.getModel(nextStage.provider, nextStage.modelId)?.name ??
       nextStage.modelId;
     const handoffPrompt = getHandoffPrompt(team, fromStage);
     // Is there a stage AFTER the one we're handing to? If so, the new tab must
@@ -886,7 +881,7 @@ export class PiSessionManager {
    * outputs so the user can preview the relay without creating tabs.
    */
   async runTagTeamTest(message: string, team: any): Promise<any> {
-    if (!this.deps?.modelRegistry) throw new Error("Model registry not available");
+    if (!this.deps?.modelRuntime) throw new Error("Model runtime not available");
     const { runTagTeamRelay } = await import("../tagteam/orchestrator");
     // Abort the test relay after 5 minutes so a stuck provider doesn't hang
     // the settings panel indefinitely. The user can re-run if it times out.
@@ -896,7 +891,7 @@ export class PiSessionManager {
       return await runTagTeamRelay({
         message,
         team,
-        modelRegistry: this.deps.modelRegistry,
+        modelRuntime: this.deps.modelRuntime,
         sessionMessages: this.session?.messages ?? [],
         signal: controller.signal,
       });
@@ -976,8 +971,7 @@ export class PiSessionManager {
     // Reuse shared deps cache instead of recreating from scratch.
     const shared = await getSharedDeps(this.agentDir, pi, newCwd);
     this._deps = {
-      authStorage: shared.authStorage,
-      modelRegistry: shared.modelRegistry,
+      modelRuntime: shared.modelRuntime,
       settingsManager: shared.settingsManager,
     };
     await this.buildRuntime(pi, newCwd, pi.SessionManager.create(newCwd));
@@ -1203,7 +1197,7 @@ export class PiSessionManager {
   async setModel(provider: string, modelId: string) {
     if (!this.session) throw new Error("Session not initialized");
     if (!this.deps) throw new Error("Deps not initialized");
-    const model = this.deps.modelRegistry.find(provider, modelId);
+    const model = this.deps.modelRuntime.getModel(provider, modelId);
     if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
     await this.session.setModel(model as any);
     this.emitState();
@@ -1238,17 +1232,17 @@ export class PiSessionManager {
    * deps cache. Call invalidateSharedDeps() before this so the cache rebuilds.
    */
   /**
-   * Mirror every custom provider's literal key into the SDK's authStorage. The
-   * live session's model registry validates selection and resolves request keys
-   * against this same authStorage, so registering here makes a model that was
-   * added OR edited mid-session take effect immediately — no restart, and no
+   * Mirror every custom provider's literal key into the shared ModelRuntime as
+   * a runtime API key. The live session's model runtime validates selection and
+   * resolves request keys against these, so registering here makes a model that
+   * was added OR edited mid-session take effect immediately — no restart, and no
    * need to re-save every model.
    */
-  private registerCustomProviderKeys(): void {
+  private async registerCustomProviderKeys(): Promise<void> {
     if (!this._deps) return;
     for (const cred of listCustomProviderCredentials()) {
       try {
-        this._deps.authStorage.set(cred.provider, { type: "api_key", key: cred.apiKey });
+        await this._deps.modelRuntime.setRuntimeApiKey(cred.provider, cred.apiKey);
       } catch {
         /* best-effort: a failed registration just means restart-to-apply */
       }
@@ -1256,24 +1250,19 @@ export class PiSessionManager {
   }
 
   async refreshModelRegistry(): Promise<void> {
-    if (!this._deps || !this.agentDir) return;
-    const pi = await import("@earendil-works/pi-coding-agent");
-    // Keep the SAME authStorage the live session was built with, and sync all
-    // custom keys into it, so selection/edits apply to the running session.
-    this.registerCustomProviderKeys();
-    // Fresh listing registry (sharing that authStorage) so add/edit/remove show
-    // up in the model list immediately.
-    this._deps.modelRegistry = pi.ModelRegistry.create(
-      this._deps.authStorage,
-      join(this.agentDir, "models.json"),
-    );
+    if (!this._deps?.modelRuntime) return;
+    // Reload models.json in place (no rebuild) so add/edit/remove of custom
+    // models show up immediately, then re-apply the custom provider keys so
+    // selection/edits apply to the running session.
+    await this._deps.modelRuntime.reloadConfig();
+    await this.registerCustomProviderKeys();
   }
 
   async getAvailableModels() {
     if (!this.deps) throw new Error("Deps not initialized");
-    const models = await this.deps.modelRegistry.getAvailable();
+    const models = await this.deps.modelRuntime.getAvailable();
     return {
-      models: (models as Model[]).map((m) => ({
+      models: (models as unknown as Model[]).map((m) => ({
         id: m.id,
         name: m.name,
         provider: m.provider,
@@ -1505,18 +1494,20 @@ export class PiSessionManager {
   // --- Misc --------------------------------------------------------------
 
   async getAuthStatus() {
-    if (!this._deps?.authStorage) return [];
-    const authStorage = this._deps.authStorage;
+    if (!this._deps?.modelRuntime) return [];
+    const modelRuntime = this._deps.modelRuntime;
     // Build the provider set from (a) the SDK's registered OAuth providers —
     // Anthropic (Claude Pro/Max), OpenAI (ChatGPT), GitHub Copilot — plus
     // (b) the legacy API-key-only providers so both surfaces show in Settings.
     const oauthProviders: { id: string; name: string }[] = [];
     try {
-      for (const p of authStorage.getOAuthProviders() ?? []) {
-        oauthProviders.push({ id: p.id, name: p.name });
+      for (const p of modelRuntime.getProviders() ?? []) {
+        if ((p as any).auth?.oauth) {
+          oauthProviders.push({ id: p.id, name: p.name });
+        }
       }
     } catch {
-      /* getOAuthProviders not available — fall back to API-key providers only */
+      /* getProviders not available — fall back to API-key providers only */
     }
     const apiKeyProviders = ["openai", "google", "anthropic"];
     // Merge, dedupe by id (OAuth "anthropic" overlaps the API-key one).
@@ -1535,15 +1526,30 @@ export class PiSessionManager {
       }
     }
 
+    // Map providerId → stored credential type so we can report how each is
+    // currently authenticated (oauth subscription vs api_key).
+    const credentialType = new Map<string, string>();
+    try {
+      for (const cred of await modelRuntime.listCredentials()) {
+        credentialType.set(cred.providerId, cred.type);
+      }
+    } catch {
+      /* listCredentials unavailable — fall back to loginType for the type field */
+    }
+
     const status: any[] = [];
     for (const { id, name, oauth } of providers) {
-      const statusInfo = authStorage.getAuthStatus(id);
-      const credential = authStorage.get(id);
-      const isOauth = credential?.type === "oauth";
+      let configured = false;
+      try {
+        configured = modelRuntime.getProviderAuthStatus(id)?.configured ?? false;
+      } catch {
+        /* provider not registered — leave unconfigured */
+      }
+      const isOauth = credentialType.get(id) === "oauth";
       status.push({
         provider: id,
         name,
-        authed: statusInfo.configured,
+        authed: configured,
         // Whether the provider offers subscription (OAuth) login at all.
         loginType: oauth ? "oauth" : "apiKey",
         // How it's currently authenticated — oauth subscription vs api_key.
@@ -1554,76 +1560,111 @@ export class PiSessionManager {
   }
 
   async setApiKey(provider: string, apiKey: string) {
-    if (!this._deps?.authStorage) return { success: false, error: "Auth not initialized" };
-    this._deps.authStorage.set(provider, { type: "api_key", key: apiKey });
-    return { success: true };
+    if (!this._deps?.modelRuntime) return { success: false, error: "Auth not initialized" };
+    try {
+      // Persist the key to auth.json via the provider's api-key login flow.
+      // (setRuntimeApiKey is in-memory only and would be lost on restart.) The
+      // api-key login prompts for the key; our interaction supplies it directly.
+      await this._deps.modelRuntime.login(provider, "api_key", {
+        prompt: async () => apiKey,
+        notify: () => {},
+      });
+      return { success: true };
+    } catch (err: any) {
+      return { success: false, error: err?.message ?? String(err) };
+    }
   }
 
   async logout(provider: string) {
-    if (!this._deps?.authStorage) return { success: false, error: "Auth not initialized" };
-    this._deps.authStorage.remove(provider);
-    return { success: true };
+    if (!this._deps?.modelRuntime) return { success: false, error: "Auth not initialized" };
+    try {
+      // logout() now removes the credential AND runs a provider refresh, which
+      // can reject (e.g. offline). Return the error contract instead of throwing.
+      await this._deps.modelRuntime.logout(provider);
+      return { success: true };
+    } catch (err: any) {
+      return { success: false, error: err?.message ?? String(err) };
+    }
   }
 
   /**
    * Run an OAuth subscription login (Claude Pro/Max, ChatGPT, Copilot) using the
-   * SDK's AuthStorage.login(). All PKCE / device-code / token-exchange work
-   * happens inside the SDK; we only bridge the interactive callbacks to the
-   * renderer over the AUTH_EVENT channel so the user sees a login modal.
+   * SDK's ModelRuntime.login(). All PKCE / device-code / token-exchange work
+   * happens inside the SDK; we only bridge the AuthInteraction (prompt/notify)
+   * to the renderer over the AUTH_EVENT channel so the user sees a login modal.
    */
   async login(providerId: string): Promise<{ success: boolean; error?: string }> {
-    if (!this._deps?.authStorage) return { success: false, error: "Auth not initialized" };
-    const authStorage = this._deps.authStorage;
+    if (!this._deps?.modelRuntime) return { success: false, error: "Auth not initialized" };
+    const modelRuntime = this._deps.modelRuntime;
     try {
-      await authStorage.login(providerId, {
-        // Browser PKCE flow (Anthropic, Codex browser method): open the authorize
-        // URL in the system browser AND tell the renderer to show a "complete
-        // sign-in" panel with a manual-code-paste fallback.
-        onAuth: (info: { url: string; instructions?: string }) => {
-          shell.openExternal(info.url).catch(() => {});
-          this.events.emit(this.AUTH_EVENT, {
-            kind: "auth",
-            provider: providerId,
-            url: info.url,
-            instructions: info.instructions,
-          });
+      await modelRuntime.login(providerId, "oauth", {
+        // Non-blocking events (auth_url / device_code / progress / info).
+        notify: (event: any) => {
+          switch (event?.type) {
+            case "auth_url": {
+              // Browser PKCE flow (Anthropic, Codex browser method): open the
+              // authorize URL AND tell the renderer to show a "complete sign-in"
+              // panel with a manual-code-paste fallback.
+              shell.openExternal(event.url).catch(() => {});
+              this.events.emit(this.AUTH_EVENT, {
+                kind: "auth",
+                provider: providerId,
+                url: event.url,
+                instructions: event.instructions,
+              });
+              break;
+            }
+            case "device_code": {
+              // Device-code flow (Copilot, Codex device method): show the user
+              // code and open the verification page prominently.
+              if (event.verificationUri) shell.openExternal(event.verificationUri).catch(() => {});
+              this.events.emit(this.AUTH_EVENT, {
+                kind: "deviceCode",
+                provider: providerId,
+                userCode: event.userCode,
+                verificationUri: event.verificationUri,
+              });
+              break;
+            }
+            case "progress":
+            case "info": {
+              this.events.emit(this.AUTH_EVENT, {
+                kind: "progress",
+                provider: providerId,
+                message: event.message,
+              });
+              break;
+            }
+          }
         },
-        // Device-code flow (Copilot, Codex device method): show the user code and
-        // open the verification page. The renderer displays the code prominently.
-        onDeviceCode: (info: { userCode: string; verificationUri: string }) => {
-          if (info.verificationUri) shell.openExternal(info.verificationUri).catch(() => {});
-          this.events.emit(this.AUTH_EVENT, {
-            kind: "deviceCode",
-            provider: providerId,
-            userCode: info.userCode,
-            verificationUri: info.verificationUri,
-          });
+        // Blocking prompts — bridge to the renderer and return its reply string.
+        prompt: (prompt: any): Promise<string> => {
+          switch (prompt?.type) {
+            case "select":
+              // Ask the renderer to pick an option (e.g. Codex browser vs device).
+              return this.requestAuthInput(providerId, "select", {
+                message: prompt.message,
+                options: (prompt.options ?? []).map((o: any) => ({ id: o.id, label: o.label })),
+              });
+            case "manual_code":
+              // Manual code paste fallback for callback-server flows.
+              return this.requestAuthInput(providerId, "manualCode", {
+                message: prompt.message || "Paste the authorization code from the browser:",
+                placeholder: prompt.placeholder ?? "code",
+              });
+            case "text":
+            case "secret":
+            default:
+              // Text/secret input (e.g. manual auth code).
+              return this.requestAuthInput(providerId, "prompt", {
+                message: prompt.message,
+                placeholder: prompt.placeholder,
+              });
+          }
         },
-        onProgress: (message: string) => {
-          this.events.emit(this.AUTH_EVENT, { kind: "progress", provider: providerId, message });
-        },
-        // Blocking: ask the renderer for a text input (e.g. manual auth code).
-        onPrompt: (prompt: { message: string; placeholder?: string; allowEmpty?: boolean }) =>
-          this.requestAuthInput(providerId, "prompt", {
-            message: prompt.message,
-            placeholder: prompt.placeholder,
-            allowEmpty: prompt.allowEmpty,
-          }),
-        // Blocking: ask the renderer to pick an option (e.g. Codex browser vs device).
-        onSelect: (prompt: { message: string; options: { id: string; label: string }[] }) =>
-          this.requestAuthInput(providerId, "select", {
-            message: prompt.message,
-            options: prompt.options,
-          }),
-        // Blocking: manual code paste fallback for callback-server flows.
-        onManualCodeInput: () =>
-          this.requestAuthInput(providerId, "manualCode", {
-            message: "Paste the authorization code from the browser:",
-            placeholder: "code",
-          }),
       });
-      // Credentials persisted by the SDK to auth.json. Rebuild deps so model
-      // registries pick up the new OAuth token.
+      // Credentials persisted by the SDK to auth.json. Rebuild deps so future
+      // tabs' runtimes pick up the new OAuth token.
       invalidateSharedDeps();
       // Rebuild THIS session's listing registry before announcing "done" so the
       // provider's (possibly newly-released) models are pulled and the model

--- a/src/main/pi/SessionPool.ts
+++ b/src/main/pi/SessionPool.ts
@@ -45,9 +45,22 @@ export class SessionPool {
    * Call after invalidateSharedDeps() so the shared cache rebuilds fresh.
    */
   async refreshAllModelRegistries(): Promise<void> {
-    await Promise.all(
-      [...this.pools.values()].map((mgr) => mgr.refreshModelRegistry().catch(() => {})),
-    );
+    // All managers for one agentDir share a single ModelRuntime, so refreshing
+    // per-manager would reload the same object N times (N× reload + custom-key
+    // re-apply, each a throttled catalog refresh). Dedupe by runtime identity so
+    // each distinct runtime reloads once. (Managers can hold different runtimes
+    // after invalidateSharedDeps rebuilds the cache, hence identity, not "first".)
+    const seen = new Set<unknown>();
+    const tasks: Promise<void>[] = [];
+    for (const mgr of this.pools.values()) {
+      const rt = mgr.deps?.modelRuntime;
+      if (rt) {
+        if (seen.has(rt)) continue;
+        seen.add(rt);
+      }
+      tasks.push(mgr.refreshModelRegistry().catch(() => {}));
+    }
+    await Promise.all(tasks);
   }
 
   /** Get or create a manager for a tab. */

--- a/src/main/pi/SharedDepsCache.ts
+++ b/src/main/pi/SharedDepsCache.ts
@@ -2,17 +2,17 @@
  * SharedDepsCache - caches expensive SDK objects that are identical
  * across all session managers (same agentDir = same deps).
  *
- * CRITICAL: We cache ONLY stateless objects (AuthStorage, ModelRegistry,
- * SettingsManager). We must NOT cache AgentSessionServices because its
- * resourceLoader holds an extension runner that gets INVALIDATED when
- * sessions are replaced (switch/fork/new/clone). Reusing a cached services
- * object across session replacements causes "stale extension ctx" errors.
+ * CRITICAL: We cache ONLY stateless objects (ModelRuntime, SettingsManager).
+ * We must NOT cache AgentSessionServices because its resourceLoader holds an
+ * extension runner that gets INVALIDATED when sessions are replaced
+ * (switch/fork/new/clone). Reusing a cached services object across session
+ * replacements causes "stale extension ctx" errors.
  */
 import { join } from "node:path";
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 
 interface CachedDeps {
-  authStorage: any;
-  modelRegistry: any;
+  modelRuntime: ModelRuntime;
   settingsManager: any;
   agentDir: string;
   createdAt: number;
@@ -31,24 +31,24 @@ export async function getSharedDeps(
   const cached = cache.get(key);
 
   if (cached && Date.now() - cached.createdAt < CACHE_TTL_MS) {
-    // Reuse auth/model but refresh cwd-dependent settings manager.
+    // Reuse the model runtime but refresh cwd-dependent settings manager.
     return {
       ...cached,
       settingsManager: pi.SettingsManager.create(cwd, agentDir),
     };
   }
 
-  // Create fresh deps - AuthStorage and ModelRegistry read JSON files.
-  const authStorage = pi.AuthStorage.create();
-  const modelRegistry = pi.ModelRegistry.create(
-    authStorage,
-    join(agentDir, "models.json"),
-  );
+  // Create fresh deps. ModelRuntime owns credentials + the model catalog and
+  // reads auth.json / models.json from disk. authPath matches the SDK default
+  // (agentDir/auth.json) that AuthStorage.create() used before the migration.
+  const modelRuntime = await pi.ModelRuntime.create({
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+  });
   const settingsManager = pi.SettingsManager.create(cwd, agentDir);
 
   const deps: CachedDeps = {
-    authStorage,
-    modelRegistry,
+    modelRuntime,
     settingsManager,
     agentDir,
     createdAt: Date.now(),

--- a/src/main/tagteam/orchestrator.ts
+++ b/src/main/tagteam/orchestrator.ts
@@ -10,16 +10,16 @@
  * agent session. This module is only for the test preview.
  */
 
+import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { TagTeamTeam, TagTeamStageResult } from "./types";
 import { buildHandoffMessage, getHandoffPrompt } from "./relay";
 
-type ModelRegistry = any;
 type AgentMessage = any;
 
 export interface RunTagTeamRelayOptions {
   message: string;
   team: TagTeamTeam;
-  modelRegistry: ModelRegistry;
+  modelRuntime: ModelRuntime;
   sessionMessages: AgentMessage[];
   /** Optional abort signal so a stuck multi-stage relay can be cancelled. */
   signal?: AbortSignal;
@@ -35,12 +35,11 @@ export async function runTagTeamRelay(opts: RunTagTeamRelayOptions): Promise<{
   teamName: string;
   stages: TagTeamStageResult[];
 }> {
-  const { message, team, modelRegistry, sessionMessages, signal } = opts;
+  const { message, team, modelRuntime, sessionMessages, signal } = opts;
 
-  // Lazily import the SDK + compat (same pattern as moa/engine.ts).
+  // Lazily import the SDK for convertToLlm (ESM + large).
   const sdk = await import("@earendil-works/pi-coding-agent");
   const convertToLlm = (sdk as any).convertToLlm as (msgs: AgentMessage[]) => any[];
-  const { completeSimple, extractText } = await importCompat();
 
   // Build base context from existing session messages.
   const baseLlm = convertToLlm(sessionMessages ?? []);
@@ -53,7 +52,7 @@ export async function runTagTeamRelay(opts: RunTagTeamRelayOptions): Promise<{
     if (signal?.aborted) break;
 
     const stage = team.stages[i];
-    const model = resolveModel(modelRegistry, stage.provider, stage.modelId);
+    const model = resolveModel(modelRuntime, stage.provider, stage.modelId);
     const modelName = model?.name ?? stage.modelId;
 
     if (!model) {
@@ -61,16 +60,6 @@ export async function runTagTeamRelay(opts: RunTagTeamRelayOptions): Promise<{
         modelName,
         role: stage.role,
         error: `Model not found: ${stage.provider}/${stage.modelId}`,
-      });
-      break;
-    }
-
-    const auth = await resolveAuth(modelRegistry, model);
-    if (!auth.ok) {
-      results.push({
-        modelName,
-        role: stage.role,
-        error: `No API key for ${stage.provider}/${stage.modelId}`,
       });
       break;
     }
@@ -94,11 +83,8 @@ export async function runTagTeamRelay(opts: RunTagTeamRelayOptions): Promise<{
         messages: [...baseLlm, { role: "user", content: userContent }],
       };
 
-      const response = await completeSimple(model, context, {
-        apiKey: auth.apiKey,
-        headers: auth.headers,
-        signal,
-      });
+      // ModelRuntime resolves auth internally from the model's provider.
+      const response = await modelRuntime.completeSimple(model, context, { signal });
 
       const output = extractText(response);
       results.push({ modelName, role: stage.role, output });
@@ -118,54 +104,23 @@ export async function runTagTeamRelay(opts: RunTagTeamRelayOptions): Promise<{
 
 // --- Helpers (mirror moa/engine.ts) ---
 
-function resolveModel(modelRegistry: ModelRegistry, provider: string, modelId: string) {
+function resolveModel(modelRuntime: ModelRuntime, provider: string, modelId: string) {
   try {
-    return modelRegistry?.find?.(provider, modelId) ?? undefined;
+    return modelRuntime?.getModel?.(provider, modelId) ?? undefined;
   } catch {
     return undefined;
   }
 }
 
-async function resolveAuth(
-  modelRegistry: ModelRegistry,
-  model: any,
-): Promise<{ ok: boolean; apiKey?: string; headers?: Record<string, string> }> {
-  try {
-    const auth = await modelRegistry?.getApiKeyAndHeaders?.(model);
-    if (!auth?.ok) return { ok: false };
-    return { ok: true, apiKey: auth.apiKey, headers: auth.headers };
-  } catch {
-    return { ok: false };
+/** Flatten an assistant message's content to plain text (text blocks only). */
+function extractText(message: any): string {
+  if (!message?.content) return "";
+  if (typeof message.content === "string") return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((c: any) => c?.type === "text")
+      .map((c: any) => c?.text ?? "")
+      .join("");
   }
-}
-
-/**
- * Import the pi-ai compat module + extract the functions we need. Delegates the
- * nested-dep resolution to moa/engine's cached getCompat (see the long comment
- * there for why direct file-path import is required) so the workaround lives in
- * exactly one place.
- */
-async function importCompat(): Promise<{
-  completeSimple: (model: any, context: any, options: any) => Promise<any>;
-  extractText: (message: any) => string;
-}> {
-  const { getCompat } = await import("../moa/engine");
-  const mod = await getCompat();
-  const complete = mod.completeSimple ?? mod.complete;
-  if (!complete) throw new Error("completeSimple not found in pi-ai/compat");
-
-  // extractText — inline since it's trivial and not exported by compat.
-  const extractText = (message: any): string => {
-    if (!message?.content) return "";
-    if (typeof message.content === "string") return message.content;
-    if (Array.isArray(message.content)) {
-      return message.content
-        .filter((c: any) => c?.type === "text")
-        .map((c: any) => c?.text ?? "")
-        .join("");
-    }
-    return "";
-  };
-
-  return { completeSimple: complete, extractText };
+  return "";
 }


### PR DESCRIPTION
## What & why
Pi SDK **0.80.6 → 0.80.10**. 0.80.8 removed `AuthStorage` + `ModelRegistry` and replaced them with a single async **`ModelRuntime`**, so this ports our entire auth/model core. Getting current unlocks Kimi K3, xAI Grok 4.5, and ongoing fixes; it also lets us **delete the fragile nested-pi-ai compat loader** that caused the v0.5.6 asar "Could not locate pi-ai/compat" bug.

## The change
One shared `ModelRuntime` (created with `authPath`/`modelsPath`) flows into every session's services, collapsing the old dual-registry + shared-authStorage juggling.

- **SharedDepsCache** → `ModelRuntime.create({ authPath: ~/.pi/agent/auth.json, modelsPath: …/models.json })`.
- **PiSessionManager** → deps `{ modelRuntime, settingsManager }`; `createAgentSessionServices({ modelRuntime })` (drops the `services.modelRegistry` re-bind); OAuth `login()` bridges the new `AuthInteraction` (`prompt`/`notify`) to the existing AUTH_EVENT channel; `setApiKey` persists via `login(provider,"api_key",…)`; `getAuthStatus` rebuilt (same `PiAuthStatus` shape); `refreshModelRegistry`→`reloadConfig`; `find`→`getModel`.
- **MOA + Tag Team** → `modelRuntime.completeSimple()` directly (auth resolved internally); removed the `getCompat`/`resolveNestedCompat` hack.
- **SessionPool** → fan-out deduped by shared-runtime identity.

Net: **–358 / +195** lines (the compat-hack removal is most of the deletion).

## Verification done
- typecheck ✓ · lint (0 errors) ✓ · **37 tests** ✓ · `npm run build` ✓
- **Independently reviewed** (all 7 spec points verified against the SDK's JS impl). Findings fixed: `setApiKey` persistence (was in-memory), `logout` try/catch, fan-out dedupe. `authPath` confirmed = `~/.pi/agent/auth.json`, so **existing users' logins survive the upgrade**.

## ⚠️ Requires live testing before merge
This is the auth/model core and a green build can't validate the runtime flows. Run `npm run dev` and confirm:
- Model switcher (⌘M) lists API-key + OAuth + custom + local models
- **OAuth login** for ChatGPT / Claude / Copilot end-to-end (browser, device-code, manual-code) — highest risk
- Custom model add/edit/remove appears live; local (Ollama) connect + select
- A **Pi Routing (MOA)** run and a **Tag Team** relay (these now use `completeSimple` — confirm in the **packaged** app too, since the compat removal changes pi-ai loading)
- Settings auth-status view

Do not merge until the OAuth and custom/local flows are confirmed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)