### PR TITLE
Auto-install updates on restart (no code signing)

### DIFF
--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -3,15 +3,84 @@ import { compareVersions } from "../shared/version";
 import { validateGitHubReleaseDmgUrl } from "../shared/updateUrl";
 import { getUpdateToken } from "./updateToken";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
-import { createWriteStream } from "node:fs";
-import { mkdir, unlink } from "node:fs/promises";
-import { execFileSync } from "node:child_process";
+import { basename, join, dirname } from "node:path";
+import { createWriteStream, constants as FS } from "node:fs";
+import { mkdir, unlink, writeFile, chmod, access } from "node:fs/promises";
+import { execFileSync, spawn } from "node:child_process";
 import { once } from "node:events";
 
 const REPO_OWNER = "rubengarciajr";
 const REPO_NAME = "pi-desktop";
 const MAX_UPDATE_BYTES = 512 * 1024 * 1024;
+
+/**
+ * Detached helper that installs a downloaded update after the app quits. It
+ * receives all paths as positional args (no string interpolation, so nothing
+ * can be injected), waits for the running app to exit, then swaps the bundle.
+ *
+ * The new bundle is staged beside the target and swapped in via `mv`, with a
+ * restore step on failure — so a copy error can never leave the user with no
+ * installed app. Quarantine is cleared so the ad-hoc-signed app launches.
+ */
+const INSTALL_SCRIPT = `#!/bin/bash
+DMG="$1"; TARGET="$2"; MNT="$3"; PID="$4"
+
+# Safety: only ever operate on a real .app bundle path.
+case "$TARGET" in
+  *.app) : ;;
+  *) exit 1 ;;
+esac
+
+# Wait (max ~60s) for the running app to exit so its bundle is replaceable.
+for _ in $(seq 1 200); do
+  kill -0 "$PID" 2>/dev/null || break
+  sleep 0.3
+done
+# NEVER swap a live bundle: if the app is somehow still running, bail out.
+if kill -0 "$PID" 2>/dev/null; then
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+
+rm -rf "$MNT"; mkdir -p "$MNT"
+# No -noverify: let hdiutil checksum the image so a corrupt download can't be
+# installed over the (about-to-be-deleted) old app.
+if ! hdiutil attach -nobrowse -readonly -mountpoint "$MNT" "$DMG" >/dev/null 2>&1; then
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+
+APP=$(ls -d "$MNT"/*.app 2>/dev/null | head -1)
+if [ -z "$APP" ]; then
+  hdiutil detach "$MNT" >/dev/null 2>&1 || true
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+
+# Stage the new bundle first so a copy failure never leaves no app installed.
+STAGING="$TARGET.new"; rm -rf "$STAGING"
+if ! ditto "$APP" "$STAGING"; then
+  rm -rf "$STAGING"; hdiutil detach "$MNT" >/dev/null 2>&1 || true
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+xattr -cr "$STAGING" 2>/dev/null || true
+
+# Atomic-ish swap. Move-aside must SUCCEED -- if it fails, TARGET still exists
+# and moving STAGING onto it would nest the new bundle inside the old one
+# (BSD mv) while still returning 0. So hard-fail rather than corrupt the bundle.
+rm -rf "$TARGET.old"
+if ! mv "$TARGET" "$TARGET.old"; then
+  rm -rf "$STAGING"; hdiutil detach "$MNT" >/dev/null 2>&1 || true
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+if ! mv "$STAGING" "$TARGET"; then
+  [ -d "$TARGET.old" ] && mv "$TARGET.old" "$TARGET"
+  rm -rf "$STAGING"; hdiutil detach "$MNT" >/dev/null 2>&1 || true
+  open "$TARGET" 2>/dev/null || true; exit 1
+fi
+rm -rf "$TARGET.old"
+
+hdiutil detach "$MNT" >/dev/null 2>&1 || true
+rm -rf "$MNT" "$DMG" 2>/dev/null || true
+open "$TARGET"
+`;
 
 /**
  * Initialize theme forwarding and update checking.
@@ -174,11 +243,8 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void
         // Non-fatal: openPath may still work if no quarantine was present.
       }
 
-      // Open the DMG in Finder — macOS mounts it and reveals the app bundle.
-      // shell.openPath returns "" on success, or an error string on failure.
-      const errMsg = await shell.openPath(destPath);
-      if (errMsg) throw new Error(`Could not open DMG: ${errMsg}`);
-
+      // Download complete. The renderer drives the next step (install & restart,
+      // or reveal in Finder as a fallback) — we no longer auto-open Finder here.
       return { success: true, path: destPath };
     } catch (e: any) {
       console.error("[updater] DMG download failed:", e);
@@ -190,14 +256,89 @@ export function initAutoUpdater(getMainWindow: () => BrowserWindow | null): void
     }
   });
 
+  // Install a downloaded update in place and relaunch, without Apple Developer
+  // ID signing. macOS's Squirrel-based auto-update requires a signed app, so
+  // instead we mount the DMG, swap the app bundle, and relaunch via a detached
+  // helper that runs after we quit. Returns { fallback: true } when auto-install
+  // can't run (dev mode, non-writable install dir, etc.) so the UI can offer the
+  // manual "reveal in Finder" path instead.
+  ipcMain.handle("pi:update:install", async (_e, args: any) => {
+    const dmgPath: string | undefined = args?.path;
+    try {
+      if (process.platform !== "darwin") {
+        return { success: false, fallback: true, error: "Auto-install is macOS-only." };
+      }
+      if (!app.isPackaged) {
+        return { success: false, fallback: true, error: "Auto-install is only available in the packaged app." };
+      }
+      if (!dmgPath) {
+        return { success: false, fallback: true, error: "No downloaded update was found." };
+      }
+      // Only ever mount+install a DMG we downloaded ourselves. This handler
+      // replaces the app's own executable, so a renderer-supplied path is a
+      // code-execution vector if not constrained to our temp dir.
+      const expectedDir = join(tmpdir(), "pi-desktop-update");
+      if (!dmgPath.startsWith(expectedDir + "/") || dmgPath.includes("..")) {
+        return { success: false, fallback: true, error: "Invalid update path." };
+      }
+      await access(dmgPath, FS.R_OK);
+
+      // Resolve the running app's bundle from its executable path:
+      //   /Applications/Pi Desktop.app/Contents/MacOS/Pi Desktop -> /Applications/Pi Desktop.app
+      const bundlePath = process.execPath.match(/^(.*\.app)\//)?.[1];
+      if (!bundlePath) {
+        return { success: false, fallback: true, error: "Could not locate the app bundle." };
+      }
+      // If we can't write the install directory (e.g. it needs admin rights),
+      // fall back to the manual Finder flow rather than failing mid-swap.
+      try {
+        await access(dirname(bundlePath), FS.W_OK);
+      } catch {
+        return { success: false, fallback: true, error: "The app's folder isn't writable without admin rights." };
+      }
+
+      const workDir = join(tmpdir(), "pi-desktop-update");
+      await mkdir(workDir, { recursive: true });
+      const scriptPath = join(workDir, "install.sh");
+      await writeFile(scriptPath, INSTALL_SCRIPT, "utf8");
+      await chmod(scriptPath, 0o755);
+      const mountPoint = join(workDir, "mnt");
+
+      const child = spawn(
+        "/bin/bash",
+        [scriptPath, dmgPath, bundlePath, mountPoint, String(process.pid)],
+        { detached: true, stdio: "ignore" },
+      );
+      child.unref();
+
+      // Quit so the detached helper can replace the bundle and relaunch us.
+      // Delay long enough for this success response to flush to the renderer
+      // before the IPC channel tears down (the child waits on our PID anyway).
+      setTimeout(() => app.quit(), 800);
+      return { success: true };
+    } catch (e: any) {
+      console.error("[updater] install failed:", e);
+      return { success: false, fallback: true, error: e?.message ?? String(e) };
+    }
+  });
+
+  // Fallback for when auto-install can't run: open the DMG in Finder so the
+  // user can drag the app to Applications themselves (the pre-auto-install flow).
+  ipcMain.handle("pi:update:reveal", async (_e, args: any) => {
+    const p: string | undefined = args?.path;
+    if (!p) return { success: false, error: "No downloaded update to open." };
+    const errMsg = await shell.openPath(p);
+    if (errMsg) return { success: false, error: errMsg };
+    return { success: true };
+  });
+
   // Clean up a previously-downloaded update DMG (optional housekeeping).
   ipcMain.handle("pi:update:cleanup", async () => {
     try {
       const dir = join(tmpdir(), "pi-desktop-update");
-      const { readdir } = await import("node:fs/promises");
-      for (const f of await readdir(dir)) {
-        await unlink(join(dir, f)).catch(() => {});
-      }
+      const { rm } = await import("node:fs/promises");
+      // Recursive: the install flow leaves a mnt/ subdirectory that unlink can't remove.
+      await rm(dir, { recursive: true, force: true });
       return { success: true };
     } catch {
       return { success: false };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -219,6 +219,8 @@ const events = {
   restartForUpdate: () => {},
   checkForUpdates: invoke("pi:update:check"),
   downloadUpdate: invoke("pi:update:download"),
+  installUpdate: invoke("pi:update:install"),
+  revealUpdate: invoke("pi:update:reveal"),
   getTheme: invoke("pi:theme:get"),
   setTheme: invoke("pi:theme:set"),
 };

--- a/src/renderer/src/components/UpdateBanner.tsx
+++ b/src/renderer/src/components/UpdateBanner.tsx
@@ -11,7 +11,9 @@ interface UpdateState {
 type DownloadState =
   | { phase: "idle" }
   | { phase: "downloading"; loaded: number; total: number }
-  | { phase: "ready" }
+  | { phase: "ready"; path?: string }
+  | { phase: "installing" }
+  | { phase: "fallback"; path?: string }
   | { phase: "error"; message: string };
 
 function formatBytes(n: number): string {
@@ -46,14 +48,14 @@ export function UpdateBanner() {
     return () => clearTimeout(timer);
   }, []);
 
-  // Listen for download progress events from the main process.
+  // Listen for download progress events from the main process. The authoritative
+  // "ready" transition comes from the awaited downloadUpdate() result (which
+  // carries the file path and fires only after quarantine stripping) — so this
+  // listener just advances the byte counter, never flips the phase.
   useEffect(() => {
     if (download.phase !== "downloading") return;
     const off = window.pi.events.onUpdateProgress(({ loaded, total }) => {
-      setDownload({ phase: "downloading", loaded, total });
-      if (total > 0 && loaded >= total) {
-        setDownload({ phase: "ready" });
-      }
+      setDownload((d) => (d.phase === "downloading" ? { phase: "downloading", loaded, total } : d));
     });
     return off;
   }, [download.phase]);
@@ -65,7 +67,7 @@ export function UpdateBanner() {
     try {
       const res = await window.pi.events.downloadUpdate({ url: state.downloadUrl });
       if (res?.success) {
-        setDownload({ phase: "ready" });
+        setDownload({ phase: "ready", path: res.path });
       } else {
         setDownload({ phase: "error", message: res?.error ?? "Download failed" });
       }
@@ -74,9 +76,35 @@ export function UpdateBanner() {
     }
   };
 
-  const pct = download.phase === "downloading" && download.total > 0
-    ? Math.round((download.loaded / download.total) * 100)
-    : 0;
+  const handleInstall = async () => {
+    if (download.phase !== "ready") return;
+    const path = download.path;
+    setDownload({ phase: "installing" });
+    try {
+      const res = await window.pi.events.installUpdate({ path });
+      // Explicit failure = pre-flight couldn't run (needs admin, dev mode, …).
+      // Offer the manual Finder path. On success the app quits & relaunches.
+      if (res && res.success === false) {
+        if (path) window.pi.events.revealUpdate({ path }).catch(() => {});
+        setDownload({ phase: "fallback", path });
+      }
+    } catch {
+      // A rejected await means the IPC channel tore down because the app is
+      // already quitting to install — that's the success path. Do NOT reveal
+      // (it would mount the DMG in Finder and fight the installer for the
+      // volume). Stay in "installing"; the app is about to relaunch.
+    }
+  };
+
+  const handleReveal = () => {
+    const path = download.phase === "ready" || download.phase === "fallback" ? download.path : undefined;
+    if (path) window.pi.events.revealUpdate({ path }).catch(() => {});
+  };
+
+  const pct =
+    download.phase === "downloading" && download.total > 0
+      ? Math.round((download.loaded / download.total) * 100)
+      : 0;
 
   return (
     <div className="no-drag fixed bottom-10 left-1/2 z-50 -translate-x-1/2 animate-fade-in">
@@ -86,16 +114,16 @@ export function UpdateBanner() {
           <span className="text-sm text-text">
             Downloading… {pct > 0 ? `${pct}%` : formatBytes(download.loaded)}
           </span>
+        ) : download.phase === "installing" ? (
+          <span className="text-sm text-text">Installing… Pi Desktop will restart</span>
         ) : download.phase === "ready" ? (
-          <span className="text-sm text-text">
-            Installer opened — drag Pi Desktop to Applications
-          </span>
+          <span className="text-sm text-text">Update ready to install</span>
+        ) : download.phase === "fallback" ? (
+          <span className="text-sm text-text">Installer opened — drag Pi Desktop to Applications</span>
         ) : download.phase === "error" ? (
           <span className="text-sm text-danger">Update failed — try again</span>
         ) : (
-          <span className="text-sm text-text">
-            Pi Desktop v{state.version} is available
-          </span>
+          <span className="text-sm text-text">Pi Desktop v{state.version} is available</span>
         )}
 
         {download.phase === "idle" && (
@@ -108,18 +136,31 @@ export function UpdateBanner() {
         )}
         {download.phase === "downloading" && (
           <div className="h-1.5 w-24 overflow-hidden rounded-full bg-bg-hover">
-            <div
-              className="h-full bg-accent transition-all"
-              style={{ width: `${pct}%` }}
-            />
+            <div className="h-full bg-accent transition-all" style={{ width: `${pct}%` }} />
           </div>
         )}
         {download.phase === "ready" && (
+          <>
+            <button
+              onClick={handleInstall}
+              className="rounded-lg bg-accent px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-accent-hover"
+            >
+              Install & Restart
+            </button>
+            <button
+              onClick={handleReveal}
+              className="text-xs text-text-faint transition-colors hover:text-text"
+            >
+              Open in Finder
+            </button>
+          </>
+        )}
+        {download.phase === "fallback" && (
           <button
-            onClick={handleDownload}
+            onClick={handleReveal}
             className="rounded-lg bg-accent px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-accent-hover"
           >
-            Reopen installer
+            Open in Finder
           </button>
         )}
         {download.phase === "error" && (
@@ -132,10 +173,7 @@ export function UpdateBanner() {
         )}
 
         {download.phase === "idle" && (
-          <button
-            onClick={() => setDismissed(true)}
-            className="text-text-faint hover:text-text"
-          >
+          <button onClick={() => setDismissed(true)} className="text-text-faint hover:text-text">
             <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -710,6 +710,15 @@ export interface PiEventApi {
   downloadUpdate: (args?: {
     url?: string;
   }) => Promise<{ success: boolean; error?: string; path?: string }>;
+  /** Install a downloaded update in place and relaunch. `fallback: true` means
+   *  auto-install couldn't run and the UI should offer revealUpdate instead. */
+  installUpdate: (args?: {
+    path?: string;
+  }) => Promise<{ success: boolean; error?: string; fallback?: boolean }>;
+  /** Open the downloaded DMG in Finder (manual drag-to-Applications fallback). */
+  revealUpdate: (args?: {
+    path?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
   getTheme: () => Promise<{ shouldUseDarkColors: boolean; themeSource: string }>;
   setTheme: (source: "system" | "light" | "dark") => Promise<{ success: boolean }>;
 }


### PR DESCRIPTION
## What & why
Gets us most of the "apps that auto-update themselves" feel **without an Apple Developer ID cert**. macOS's Squirrel-based auto-update flatly requires a signed app, and this one is ad-hoc signed — so instead of that path, the updater now does **Download → Install & Restart**, swapping the app bundle in place via a detached helper.

## The flow
- `pi:update:download` — downloads the DMG, validates the URL (GitHub host, https, `.dmg`), size-caps it, strips quarantine, returns the path. No longer auto-opens Finder.
- **`pi:update:install`** (new) — pre-flight checks (packaged, macOS, `.app` bundle locatable from `process.execPath`, install dir writable), then spawns a **static** bash helper (paths passed as argv — no interpolation) that: waits for the app PID to exit → mounts the DMG → stages the new bundle beside the old → **atomically swaps with restore-on-failure** → clears quarantine → relaunches. Any pre-flight failure returns `{fallback:true}`.
- **`pi:update:reveal`** (new) — the manual "open DMG in Finder" fallback, so nothing regresses when auto-install can't run (e.g. app needs admin to write).
- **UpdateBanner** — `Download` → `Install & Restart` (primary) + an "Open in Finder" fallback.

## Safety
Every failure path degrades to the current manual Finder flow rather than bricking the install. Independently reviewed; fixes applied for a **Critical** bundle-corruption path (BSD `mv` move-aside now hard-fails instead of silently nesting), a live-bundle-swap guard (abort if the app is still running), **renderer-supplied path validation** (constrained to our temp dir — it replaces the app's own binary), DMG checksum verification (dropped `-noverify`), and a quit-race fix.

## Verification
typecheck ✓ · lint (0 errors) ✓ · **37 tests** ✓ · build ✓

## ⚠️ Testing note
The install path can't be exercised until an **installed** build updates to a **newer** release — dev mode intentionally returns the Finder fallback, so the *first* release carrying this can't self-test; the *next* one proves it. Gated and fallback-safe, but road-test before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)