### PR TITLE
fix: preset-added models 401, and stale auth badge after OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Quick presets produced 401s when adding a model.** A preset filled the provider field with its display label, which was then slugified into the models.json key — so `Grok (xAI)` became the provider `grok-(xai)`, never matching the same provider typed by hand. Worse, a blank API key was stored as the literal `$API_KEY`, which the SDK resolves as an *environment variable* of that name; it is never set, so requests went out unauthenticated and came back 401 while the save reported success. Presets now carry an explicit stable `providerId`, provider names are slugified properly, and a remote provider without a key is rejected in the form and again in the main process. Note that "Test connection" never caught this: it probes `GET {baseUrl}/models` with the key currently typed in the form, bypassing `ModelRuntime` and the stored config entirely.
+- **OAuth logins looked like they had failed until the app was restarted.** `SettingsPanel` read auth status once on mount and never re-read it, so after approving a device code (xAI, Codex) the provider row kept showing "Not connected". The store's `done` handler appeared to refresh but discarded the result and returned no state. Settings now subscribes to `onAuthEvent` and refreshes on `done`/`error`, so the badge updates the moment authorization completes.
+- **The device-code modal showed a raw provider id.** `PROVIDER_LABELS` had no `xai` entry, so the dialog read "Connect xai" instead of "Connect xAI (Grok)".
+
+---
+
 ## [0.6.1] — 2026-07-17
 
 ### Fixed

--- a/src/main/models.test.ts
+++ b/src/main/models.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { slugifyProvider } from "./models";
+
+describe("slugifyProvider", () => {
+  it("leaves an already-clean id untouched", () => {
+    expect(slugifyProvider("minimax")).toBe("minimax");
+    expect(slugifyProvider("xiaomi-mimo")).toBe("xiaomi-mimo");
+  });
+
+  it("keeps dots, so z.ai stays z.ai", () => {
+    expect(slugifyProvider("z.ai")).toBe("z.ai");
+  });
+
+  it("strips the punctuation that prose preset labels carry", () => {
+    // These are the exact labels that used to reach models.json verbatim and
+    // produce keys like `grok-(xai)` / `codex-/-openai`.
+    expect(slugifyProvider("Grok (xAI)")).toBe("grok-xai");
+    expect(slugifyProvider("Codex / OpenAI")).toBe("codex-openai");
+    expect(slugifyProvider("Z.ai (GLM)")).toBe("z.ai-glm");
+  });
+
+  it("lowercases and collapses whitespace", () => {
+    expect(slugifyProvider("  Xiaomi   MiMo  ")).toBe("xiaomi-mimo");
+  });
+
+  it("never emits leading/trailing or doubled separators", () => {
+    expect(slugifyProvider("!!Grok!!")).toBe("grok");
+    expect(slugifyProvider("a  &  b")).toBe("a-b");
+    expect(slugifyProvider(".hidden.")).toBe("hidden");
+  });
+
+  it("returns empty for input with nothing usable, so callers can reject it", () => {
+    expect(slugifyProvider("()")).toBe("");
+    expect(slugifyProvider("   ")).toBe("");
+  });
+});

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -64,6 +64,24 @@ export function listCustomModels(): { providers: Record<string, { baseUrl?: stri
   return { providers: data.providers };
 }
 
+/**
+ * Slugify a user- or preset-supplied provider name into a models.json key.
+ * Previously this was just lowercase + space→dash, so a prose label such as
+ * "Grok (xAI)" became the key `grok-(xai)`: punctuation survived, and the same
+ * provider added via preset vs. typed by hand produced two separate entries.
+ * Keep only characters that read cleanly as an id, and collapse the runs the
+ * stripping leaves behind.
+ */
+export function slugifyProvider(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9._-]/g, "")
+    .replace(/-{2,}/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
 /** True for localhost / loopback base URLs (local model servers). */
 function isLocalUrl(url: string): boolean {
   return /\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(:|\/|$)/i.test(url ?? "");
@@ -135,8 +153,17 @@ export function addCustomModel(config: {
 }): { success: boolean; error?: string } {
   const data = readModelsJson();
 
-  const providerKey = config.provider.toLowerCase().replace(/\s+/g, "-");
+  const providerKey = slugifyProvider(config.provider);
+  if (!providerKey) {
+    return { success: false, error: "Provider name must contain a letter or number." };
+  }
   const apiKey = normalizeApiKey(config.apiKey, config.baseUrl);
+  // Refuse to persist the unresolved placeholder for a remote provider. The SDK
+  // reads "$API_KEY" as an env var that is never set, so the provider would be
+  // saved successfully and then 401 on every request with no visible cause.
+  if (apiKey === "$API_KEY") {
+    return { success: false, error: "An API key is required for remote providers." };
+  }
 
   // Create or update the provider.
   if (!data.providers[providerKey]) {
@@ -210,7 +237,7 @@ export function editCustomModel(config: {
   }
 
   // Upsert the edited model under its (possibly new) provider key.
-  const providerKey = config.provider.toLowerCase().replace(/\s+/g, "-");
+  const providerKey = slugifyProvider(config.provider);
   if (!data.providers[providerKey]) {
     data.providers[providerKey] = { baseUrl: config.baseUrl, api: config.api, apiKey, models: [] };
   } else {

--- a/src/renderer/src/components/AuthFlowModal.tsx
+++ b/src/renderer/src/components/AuthFlowModal.tsx
@@ -186,4 +186,5 @@ const PROVIDER_LABELS: Record<string, string> = {
   "github-copilot": "GitHub Copilot",
   openai: "OpenAI",
   google: "Google",
+  xai: "xAI (Grok)",
 };

--- a/src/renderer/src/components/model/ModelView.tsx
+++ b/src/renderer/src/components/model/ModelView.tsx
@@ -37,6 +37,13 @@ interface EditTarget {
 interface Preset {
   id: string;
   label: string;
+  /**
+   * Provider id written to models.json. Kept separate from `label` on purpose:
+   * the label is prose ("Grok (xAI)") and slugifying it produced ids like
+   * `grok-(xai)`, which don't match what a user types by hand and so created a
+   * second, parallel provider entry. This is the stable identity.
+   */
+  providerId: string;
   description: string;
   baseUrl: string;
   api: string;
@@ -50,9 +57,15 @@ interface Preset {
   signupUrl: string;
 }
 
+/** Mirrors isLocalUrl() in src/main/models.ts — local servers ignore the key. */
+function isLocalBaseUrl(url: string): boolean {
+  return /\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(:|\/|$)/i.test(url ?? "");
+}
+
 const PRESETS: Preset[] = [
   {
     id: "local",
+    providerId: "local",
     label: "Local",
     description: "Ollama / LM Studio / llama.cpp",
     // Generic localhost template — 11434 is Ollama's port; change it for
@@ -68,6 +81,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "claude",
+    providerId: "claude",
     label: "Claude",
     description: "Anthropic",
     baseUrl: "https://api.anthropic.com/v1",
@@ -80,6 +94,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "codex",
+    providerId: "openai",
     label: "Codex / OpenAI",
     description: "OpenAI",
     baseUrl: "https://api.openai.com/v1",
@@ -92,6 +107,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "zai",
+    providerId: "z.ai",
     label: "Z.ai (GLM)",
     description: "Zhipu AI",
     baseUrl: "https://api.z.ai/api/paas/v4",
@@ -104,6 +120,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "minimax",
+    providerId: "minimax",
     label: "MiniMax",
     description: "MiniMax M3",
     baseUrl: "https://api.minimax.chat/v1",
@@ -117,6 +134,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "mimo",
+    providerId: "xiaomi-mimo",
     label: "Xiaomi MiMo",
     description: "MiMo V2.5 Pro",
     baseUrl: "https://api.xiaomimimo.com/v1",
@@ -129,6 +147,7 @@ const PRESETS: Preset[] = [
   },
   {
     id: "grok",
+    providerId: "grok",
     label: "Grok (xAI)",
     description: "Grok 4",
     baseUrl: "https://api.x.ai/v1",
@@ -423,7 +442,7 @@ function AddModelForm({ onDone, initial }: { onDone: () => void; initial?: EditT
   };
 
   const applyPreset = (preset: Preset) => {
-    setProvider(preset.label);
+    setProvider(preset.providerId);
     setBaseUrl(preset.baseUrl);
     setApi(preset.api);
     setModelId(preset.modelId);
@@ -437,6 +456,15 @@ function AddModelForm({ onDone, initial }: { onDone: () => void; initial?: EditT
   const handleSubmit = async () => {
     if (!provider.trim() || !baseUrl.trim() || !modelId.trim()) {
       setError("Provider, Base URL, and Model ID are required.");
+      return;
+    }
+    // A blank key used to be stored as the literal "$API_KEY", which the SDK
+    // then resolved as an *environment variable* of that name. It is never set,
+    // so requests went out unauthenticated and came back 401 — with nothing in
+    // the UI to explain why. Remote providers must have a key up front. On edit
+    // a blank field still means "keep the existing key", so only block on add.
+    if (!isEdit && !apiKey.trim() && !isLocalBaseUrl(baseUrl)) {
+      setError("An API key is required for remote providers.");
       return;
     }
     setSaving(true);

--- a/src/renderer/src/components/settings/SettingsView.tsx
+++ b/src/renderer/src/components/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAppStore } from "../../store/useAppStore";
 import { GitHubIcon } from "../GitHubBadge";
 import { PiChangelog } from "./PiChangelog";
@@ -76,16 +76,27 @@ function SettingsPanel() {
   const [ghToken, setGhToken] = useState("");
   const [ghVerifying, setGhVerifying] = useState(false);
 
+  // Re-fetch auth status (called after login/logout/apiKey-save so the UI updates).
+  const refreshAuth = useCallback(() => {
+    window.pi.api.getAuthStatus().then(setAuthStatus).catch(() => {});
+  }, []);
+
   useEffect(() => {
     refreshAuth();
     window.pi.api.getCwd().then(setCwd).catch(() => {});
     window.pi.github.getAuthStatus().then((s: GitHubAuth) => setGhAuth(s)).catch(() => {});
-  }, []);
+  }, [refreshAuth]);
 
-  // Re-fetch auth status (called after login/logout/apiKey-save so the UI updates).
-  const refreshAuth = () => {
-    window.pi.api.getAuthStatus().then(setAuthStatus).catch(() => {});
-  };
+  // Reflect OAuth results live. The device-code flow finishes in the main
+  // process, so without this the row kept showing "Not connected" until the
+  // view was remounted — users reasonably read that as a failed login and
+  // restarted the app. ModelView already did this; Settings did not.
+  useEffect(() => {
+    const off = window.pi.events.onAuthEvent((message: any) => {
+      if (message?.kind === "done" || message?.kind === "error") refreshAuth();
+    });
+    return () => { off?.(); };
+  }, [refreshAuth]);
 
   return (
     <div className="space-y-6">

--- a/src/renderer/src/store/useAppStore.ts
+++ b/src/renderer/src/store/useAppStore.ts
@@ -730,8 +730,10 @@ export const useAppStore = create<AppState>((set, get) => ({
             } as AuthFlow,
           };
         case "done":
-          // Refresh auth status so the new credential shows as authenticated.
-          window.pi.api.getAuthStatus().catch(() => {});
+          // Just close the modal. Refreshing auth status is the subscribing
+          // view's job (SettingsView / ModelView both listen for "done") — the
+          // fire-and-forget getAuthStatus() that used to live here discarded its
+          // result and updated nothing.
           return { authFlow: null };
         case "error":
           return {


### PR DESCRIPTION
Fixes two defects in the provider/model auth flow, reported as: *"adding a model with the presets doesn't work — 401 — but adding it manually and testing the connection works perfectly"* and *"after the device is authorized it still says you're not logged in until you restart."*

## 1. Quick presets produced a 401

`applyPreset()` filled the provider field with the preset's **display label**, and `addCustomModel()` slugified that into the models.json key. Punctuation survived:

| Preset label | Key it produced |
|---|---|
| `Grok (xAI)` | `grok-(xai)` |
| `Codex / OpenAI` | `codex-/-openai` |
| `Z.ai (GLM)` | `z.ai-(glm)` |

So a preset-added provider never matched the same one typed by hand — you got two parallel entries.

The 401 itself came from the key path. `normalizeApiKey()` rewrites a blank key to the literal `"$API_KEY"`, and the SDK reads a leading `$` as an **environment variable reference**. `API_KEY` is never set, so requests went out unauthenticated and returned 401 — while the save reported success and `listCustomProviderCredentials()` skipped the entry (it filters `$…`), leaving nothing in the UI to explain the failure.

**Why "Test connection" never caught it:** `pi:models.testConnection` issues a raw `GET {baseUrl}/models` using the key *currently typed in the form*, bypassing `ModelRuntime` and never reading the stored config. A passing test said nothing about what was actually saved — which is exactly why the manual path appeared to work and the preset path didn't.

## 2. OAuth logins looked like they had failed until restart

`SettingsPanel` fetched auth status on mount and never again, so after approving a device code the row kept reading "Not connected". The store's `done` handler looked like it refreshed, but discarded the result and returned no state, so nothing re-rendered:

```ts
window.pi.api.getAuthStatus().catch(() => {});   // result thrown away
return { authFlow: null };
```

`ModelView` already subscribed to `onAuthEvent`; Settings did not.

## Changes

- **`ModelView.tsx`** — presets carry an explicit stable `providerId` (`grok`, `openai`, `z.ai`, …) instead of reusing the prose label; a blank key on a remote provider is blocked in the form.
- **`models.ts`** — new exported `slugifyProvider()`; `addCustomModel()` refuses to persist `$API_KEY` for a remote provider and rejects a provider name with no usable characters. Guarded in the main process too, so IPC can't write a bad entry regardless of UI.
- **`SettingsView.tsx`** — subscribes to `onAuthEvent`, refreshes on `done`/`error`.
- **`useAppStore.ts`** — removed the dead fire-and-forget `getAuthStatus()`.
- **`AuthFlowModal.tsx`** — added the missing `xai` label, so the dialog reads "Connect xAI (Grok)" not "Connect xai".

## Reviewer notes

- **No migration needed.** Existing `z.ai`, `xiaomi-mimo`, and `minimax` provider keys slug to themselves under `slugifyProvider()`, so stored configs are untouched. Only newly-added providers get the corrected ids.
- **Deliberately not changed:** two preset base URLs disagree with what appears to work in practice — `api.minimax.chat/v1` + `openai-completions` vs `api.minimax.io/anthropic` + `anthropic-messages`, and `api.xiaomimimo.com/v1` vs `token-plan-sgp.xiaomimimo.com/v1`. All four hosts are live and return 401 on a bad token, so a valid key against the wrong endpoint is a plausible *second*, independent cause of 401s. Confirming which URL is correct per account tier needs a real key, so it's left for a follow-up rather than guessed at here.

## Testing

- 6 new cases for `slugifyProvider`, including the exact preset labels that regressed.
- Full suite: **43 passed**. `eslint` clean; `tsc --noEmit` clean for both `tsconfig.web.json` and `tsconfig.node.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
