### PR TITLE
feat: collapse long boxes in the chat stream

### DIFF
--- a/src/renderer/src/components/chat/ClampBox.tsx
+++ b/src/renderer/src/components/chat/ClampBox.tsx
@@ -1,0 +1,47 @@
+import { useState, type ReactNode } from "react";
+
+/**
+ * Collapses tall stream content to a fixed height with a fade-out and an
+ * expand/collapse toggle. Used for the "long boxes" in the chat stream —
+ * code blocks, pasted user messages, diffs, and tool args — so scrollback
+ * stays compact and anything can still be reviewed in full on demand.
+ *
+ * Callers decide *whether* content is long (line counts are cheap where the
+ * content is produced); ClampBox only handles the presentation.
+ */
+export function ClampBox({
+  label,
+  maxHeight = 300,
+  fade = true,
+  buttonClassName,
+  children,
+}: {
+  /** Toggle text while collapsed, e.g. "Show all 132 lines". */
+  label: string;
+  /** Collapsed height in px. */
+  maxHeight?: number;
+  /** Fade the clipped edge into the background (disable over tinted surfaces). */
+  fade?: boolean;
+  buttonClassName?: string;
+  children: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div>
+      <div className="relative">
+        <div style={expanded ? undefined : { maxHeight }} className={expanded ? undefined : "overflow-hidden"}>
+          {children}
+        </div>
+        {!expanded && fade && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-bg" />
+        )}
+      </div>
+      <button
+        onClick={() => setExpanded((e) => !e)}
+        className={buttonClassName ?? "mt-1 text-[10px] text-accent hover:underline"}
+      >
+        {expanded ? "Show less" : label}
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/src/components/chat/DiffViewer.tsx
+++ b/src/renderer/src/components/chat/DiffViewer.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from "react";
 import { useAppStore } from "../../store/useAppStore";
+import { ClampBox } from "./ClampBox";
 
 /**
  * Renders a unified diff (from edit tool's details.patch) with syntax coloring.
@@ -24,18 +25,36 @@ export const DiffViewer = memo(function DiffViewer({ toolCallId }: { toolCallId:
         <span className="font-medium text-text">Diff</span>
         <span className="truncate text-text-faint font-mono">{filePath}</span>
       </summary>
-      <div className="border-t border-border overflow-x-auto">
-        <pre className="px-3 py-2 text-[11px] font-mono leading-relaxed">
-          {lines.map((line, i) => (
-            <div key={i} className={diffLineClass(line)}>
-              {line || " "}
-            </div>
-          ))}
-        </pre>
+      <div className="border-t border-border">
+        {lines.length > 24 ? (
+          <ClampBox
+            label={`Show full diff (${lines.length} lines)`}
+            maxHeight={320}
+            buttonClassName="block w-full border-t border-border bg-bg-subtle/60 px-3 py-1 text-left text-[10px] text-accent hover:bg-bg-subtle"
+          >
+            <DiffLines lines={lines} />
+          </ClampBox>
+        ) : (
+          <DiffLines lines={lines} />
+        )}
       </div>
     </details>
   );
 });
+
+function DiffLines({ lines }: { lines: string[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <pre className="px-3 py-2 text-[11px] font-mono leading-relaxed">
+        {lines.map((line, i) => (
+          <div key={i} className={diffLineClass(line)}>
+            {line || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
 
 function diffLineClass(line: string): string {
   if (line.startsWith("+++") || line.startsWith("---")) return "text-text-faint";

--- a/src/renderer/src/components/chat/DiffViewer.tsx
+++ b/src/renderer/src/components/chat/DiffViewer.tsx
@@ -30,6 +30,7 @@ export const DiffViewer = memo(function DiffViewer({ toolCallId }: { toolCallId:
           <ClampBox
             label={`Show full diff (${lines.length} lines)`}
             maxHeight={320}
+            fade={false}
             buttonClassName="block w-full border-t border-border bg-bg-subtle/60 px-3 py-1 text-left text-[10px] text-accent hover:bg-bg-subtle"
           >
             <DiffLines lines={lines} />

--- a/src/renderer/src/components/chat/Markdown.tsx
+++ b/src/renderer/src/components/chat/Markdown.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { looksLikePath } from "../../../../shared/filePath";
 import { FilePath } from "./FilePath";
+import { ClampBox } from "./ClampBox";
 
 const SyntaxCodeBlock = lazy(() => import("./SyntaxCodeBlock"));
 
@@ -17,6 +18,9 @@ interface MarkdownProps {
  * CodeBlock and re-ran Prism highlighting over code whose content never
  * changed. Now unchanged code blocks skip Prism entirely.
  */
+/** Code blocks taller than this many lines start collapsed in the stream. */
+const CODE_COLLAPSE_LINES = 24;
+
 const CodeBlock = memo(function CodeBlock({
   language,
   value,
@@ -25,6 +29,20 @@ const CodeBlock = memo(function CodeBlock({
   value: string;
 }) {
   const lineCount = value.split("\n").length;
+  // Scroll long lines inside the block so they never widen the chat canvas.
+  const body = (
+    <div className="overflow-x-auto">
+      <Suspense
+        fallback={
+          <pre className="m-0 whitespace-pre px-3.5 py-2.5 font-mono text-xs leading-6 text-text-muted">
+            {value}
+          </pre>
+        }
+      >
+        <SyntaxCodeBlock language={language} value={value} />
+      </Suspense>
+    </div>
+  );
   return (
     <div className="group relative my-2.5 max-w-full overflow-hidden rounded-lg border border-border bg-bg">
       <div className="flex items-center justify-between border-b border-border bg-bg-subtle px-3 py-1.5">
@@ -41,18 +59,17 @@ const CodeBlock = memo(function CodeBlock({
           Copy
         </button>
       </div>
-      {/* Scroll long lines inside the block so they never widen the chat canvas. */}
-      <div className="overflow-x-auto">
-        <Suspense
-          fallback={
-            <pre className="m-0 whitespace-pre px-3.5 py-2.5 font-mono text-xs leading-6 text-text-muted">
-              {value}
-            </pre>
-          }
+      {lineCount > CODE_COLLAPSE_LINES ? (
+        <ClampBox
+          label={`Show all ${lineCount} lines`}
+          maxHeight={300}
+          buttonClassName="block w-full border-t border-border bg-bg-subtle/60 px-3 py-1 text-left text-[10px] text-accent hover:bg-bg-subtle"
         >
-          <SyntaxCodeBlock language={language} value={value} />
-        </Suspense>
-      </div>
+          {body}
+        </ClampBox>
+      ) : (
+        body
+      )}
     </div>
   );
 });

--- a/src/renderer/src/components/chat/MessageItem.tsx
+++ b/src/renderer/src/components/chat/MessageItem.tsx
@@ -3,6 +3,7 @@ import type { ChatMessage } from "../../store/useAppStore";
 import { ToolCallBlock } from "./ToolCallBlock";
 import { DiffViewer } from "./DiffViewer";
 import { Markdown } from "./Markdown";
+import { ClampBox } from "./ClampBox";
 
 // Memoized: the store hands out a new message object only when that specific
 // message changes, so unchanged history is skipped on every streaming delta.
@@ -19,10 +20,24 @@ function UserMessage({ message }: { message: ChatMessage }) {
     .filter((b) => b.type === "text")
     .map((b) => b.text)
     .join("");
+  const lineCount = text.split("\n").length;
+  // Big pastes (logs, files, long prompts) collapse so scrollback stays usable.
+  const isLong = lineCount > 12 || text.length > 1200;
+  const body = <p className="whitespace-pre-wrap break-words">{text}</p>;
   return (
     <div className="group flex justify-end py-2 animate-slide-up">
       <div className="max-w-[80%] rounded-2xl rounded-br-md bg-user/15 px-4 py-2.5 text-[13px] text-text selectable">
-        <p className="whitespace-pre-wrap break-words">{text}</p>
+        {isLong ? (
+          <ClampBox
+            label={lineCount > 1 ? `Show all ${lineCount} lines` : "Show full message"}
+            maxHeight={220}
+            fade={false}
+          >
+            {body}
+          </ClampBox>
+        ) : (
+          body
+        )}
       </div>
     </div>
   );

--- a/src/renderer/src/components/chat/ToolCallBlock.tsx
+++ b/src/renderer/src/components/chat/ToolCallBlock.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo, useState } from "react";
 import { useAppStore } from "../../store/useAppStore";
 import { ToolRenderedResult } from "./ToolRenderer";
 import { FilePath, linkifyPaths } from "./FilePath";
+import { ClampBox } from "./ClampBox";
 
 /** Tools whose one-line summary IS a file path (so it gets the reveal/copy menu). */
 const PATH_TOOLS = new Set(["read", "edit", "write", "ls"]);
@@ -119,12 +120,23 @@ function ToolArgs({ tool }: { tool: any }) {
     [tool.args],
   );
   if (!tool.args) return null;
+  // Args can embed entire file contents (e.g. a `write` call) — clamp them.
+  const lineCount = argsText.split("\n").length;
+  const body = (
+    <pre className="overflow-x-auto rounded bg-bg px-2 py-1.5 text-[11px] text-text-muted font-mono">
+      {argsText}
+    </pre>
+  );
   return (
     <div className="mb-2">
       <div className="mb-1 text-[10px] uppercase tracking-wider text-text-faint">Args</div>
-      <pre className="overflow-x-auto rounded bg-bg px-2 py-1.5 text-[11px] text-text-muted font-mono">
-        {argsText}
-      </pre>
+      {lineCount > 15 ? (
+        <ClampBox label={`Show all ${lineCount} lines`} maxHeight={240}>
+          {body}
+        </ClampBox>
+      ) : (
+        body
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Long stream content now starts collapsed with a "Show all N lines" toggle so scrollback stays compact, while anything can still be reviewed in full on demand. One shared `ClampBox` primitive (fixed-height clip + fade + expand/collapse) applied to the four unbounded surfaces:

- **Code blocks** over 24 lines — toggle styled as a footer bar of the code box
- **User messages** over 12 lines / 1200 chars — big pastes (logs, files)
- **Diffs** over 24 lines
- **Tool args** over 15 lines — a `write` call embeds the whole file

Tool *output* already clamped at 15 lines and thinking already collapses via `<details>` — both unchanged.

## Test plan

- Gates: typecheck ✅ · lint 0 errors ✅ · 57/57 tests ✅ · build ✅
- Verified against a real 110-message session via a Playwright `_electron` walkthrough: 84 over-limit code blocks (up to 281 lines) all received toggles; expand/collapse verified both ways with screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)