### PR TITLE
chore: upgrade Pi SDK 0.84.3 → 0.84.4 (0.85.0 is broken upstream, skipped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **Pi SDK 0.84.3 → 0.84.4.** A maintenance bump with no breaking changes and no app-code changes required. The most relevant fix for Pi Desktop is inherited from the SDK: the `bash`, `edit`, `find`, `grep`, `ls`, `read`, and `write` tools previously **ignored `ctx.cwd`**, so an agent could operate against the process working directory instead of the session's own folder. That directly affects v0.7.0's worktree sessions, whose entire premise is a per-session isolated checkout. Also brings `ui_prompt_start`/`ui_prompt_end` extension events, RPC `clear_queue`, terminal capability overrides, and an experimental DeepSeek V4 Flash Vision model.
+
+### Notes
+- **Deliberately NOT upgraded to 0.85.0 — that release is broken for library consumers.** `pi-coding-agent@0.85.0` reaches `@earendil-works/pi-server` through its own package root (`dist/index.js` re-exports `main.js`, which imports `dist/experimental/server.js`, which imports `@earendil-works/pi-server`), but never declares that package as a dependency. `@earendil-works/pi-server@0.85.0` is published, so it resolves inside the upstream monorepo via workspace linking — but a fresh `npm install` of the published package does not get it, and because ESM resolves the whole module graph eagerly, **any** `import("@earendil-works/pi-coding-agent")` throws `ERR_MODULE_NOT_FOUND`. Pi Desktop imports the package root throughout the main process, so 0.85.0 would prevent the app from starting. Revisit when upstream declares the dependency (or moves the server export off the root entry point).
+
+---
+
 ## [0.7.0] — 2026-08-24
 
 ### Added

--- a/docs/APP_OVERVIEW.md
+++ b/docs/APP_OVERVIEW.md
@@ -6,7 +6,7 @@ Pi Desktop is a native macOS desktop application that wraps the [Pi coding agent
 
 Built with **Electron 41**, **React 18**, **TypeScript**, and **Tailwind CSS**.
 
-**Current version:** 0.6.3
+**Current version:** 0.7.0
 **License:** MIT
 **Platform:** macOS (Apple Silicon + Intel)
 **Download:** [github.com/rubengarciajr/pi-desktop/releases](https://github.com/rubengarciajr/pi-desktop/releases)
@@ -191,7 +191,7 @@ Arrow-key navigation with autocomplete. Commands load with retry/backoff to hand
 | Styling  | Tailwind CSS 3 with CSS variables (RGB triplets for opacity support) |
 | State    | Zustand                                                              |
 | Bundler  | electron-vite (Vite)                                                 |
-| AI SDK   | @earendil-works/pi-coding-agent 0.84.1                               |
+| AI SDK   | @earendil-works/pi-coding-agent 0.84.4                               |
 | Build    | electron-builder (DMG output)                                        |
 | CI       | GitHub Actions (auto-build on tag push)                              |
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Pi Desktop — Features
 
-_Website-ready feature copy. Version 0.6.3 · macOS (Apple Silicon + Intel)._
+_Website-ready feature copy. Version 0.7.0 · macOS (Apple Silicon + Intel)._
 
 **Pi Desktop is a native macOS app for the [Pi coding agent](https://pi.dev) — a polished, multi-tab GUI that replaces the terminal. No CLI, no Node.js setup. Just open it and start.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.3",
+        "@earendil-works/pi-coding-agent": "^0.84.4",
         "@esbuild/darwin-arm64": "^0.28.1",
         "@types/react-syntax-highlighter": "^15.5.13",
         "react-markdown": "^10.1.0",
@@ -366,17 +366,17 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.3.tgz",
-      "integrity": "sha512-Yr2p9PubrbFZmYEPYI+C8KmZP9xlFuLDnAG64RtU0ZDgrdiXYWa+y7WGyJO5OlqPliOkVCMd9IzVszO3/t0D0w==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.4.tgz",
+      "integrity": "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.3",
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-client": "^0.84.3",
-        "@earendil-works/pi-protocol": "^0.84.3",
-        "@earendil-works/pi-tui": "^0.84.3",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-client": "^0.84.4",
+        "@earendil-works/pi-protocol": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -839,12 +839,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.4.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.3",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -855,13 +855,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
@@ -878,19 +878,19 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.4.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.3"
+        "@earendil-works/pi-protocol": "^0.84.4"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.4.tgz",
       "license": "MIT",
       "dependencies": {
         "typebox": "1.3.7"
@@ -900,16 +900,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.3.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -4723,6 +4723,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4795,6 +4796,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -8424,6 +8426,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.3",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
     "@esbuild/darwin-arm64": "^0.28.1",
     "@types/react-syntax-highlighter": "^15.5.13",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
Tracks upstream [`earendil-works/pi` · packages/coding-agent](https://github.com/earendil-works/pi/tree/main/packages/coding-agent). Upstream published **0.84.4** and **0.85.0**. This takes 0.84.4 and deliberately stops short of 0.85.0.

## 🚫 0.85.0 cannot be consumed as a library

Its package root reaches a dependency it never declares:

```
dist/index.js          (package root — line 33 re-exports `main`)
  └─ dist/main.js:42
       └─ dist/experimental/server.js:10
            └─ @earendil-works/pi-server   ← NOT in dependencies
```

`@earendil-works/pi-server@0.85.0` **is** published to npm, so it resolves inside the upstream monorepo via workspace linking and their CI passes. A fresh `npm install` of the published package does not get it. And because ESM resolves the entire module graph eagerly, **any** `import("@earendil-works/pi-coding-agent")` throws:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@earendil-works/pi-server'
imported from .../pi-coding-agent/dist/experimental/server.js
```

Pi Desktop imports the package root throughout the main process, so **0.85.0 would prevent the app from starting**. Verified directly against both versions: 0.85.0 fails, 0.84.4 imports cleanly.

Worth reporting upstream — the fix is either declaring the dependency or moving the server export off the root entry point.

## What 0.84.4 brings

No breaking changes, no app-code changes required. The most relevant item is inherited from the SDK:

- **`bash`, `edit`, `find`, `grep`, `ls`, `read`, `write` previously ignored `ctx.cwd`** ([#8627](https://github.com/earendil-works/pi/pull/8627)) — an agent could act on the process working directory rather than the session's own folder. That matters directly for **v0.7.0 worktree sessions**, whose entire premise is a per-session isolated checkout.
- `ui_prompt_start` / `ui_prompt_end` extension events, RPC `clear_queue`, terminal capability overrides, experimental DeepSeek V4 Flash Vision.

## Verification

Ran the runtime API-surface probe — the check that caught `reloadConfig()`'s removal in 0.82. Types prove little here: the SDK arrives via dynamic `import()`.

| Surface | Result |
|---|---|
| `createAgentSessionServices`, `createAgentSessionFromServices`, `createAgentSessionRuntime`, `DefaultPackageManager`, `ModelRuntime` | present |
| `ModelRuntime`: `completeSimple`, `getModel`, `login`, `logout`, `listCredentials`, `getProviders`, `getProviderAuthStatus`, `getAvailable`, `setRuntimeApiKey`, `refresh` | present |
| `VERSION` export | reports `0.84.4` |

`typecheck`, `lint` (0 errors; 2 pre-existing warnings), `test` (**57 passed**), and `electron-vite build` all pass.

## Also included

Two stale doc version strings left over from the v0.7.0 release: `APP_OVERVIEW.md` and `FEATURES.md` both still said 0.6.3.

## Reviewer note

Merging needs `--admin`: `main` requires the `Build & Release` check, but that workflow only triggers on `push: tags: v*` and never runs on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
